### PR TITLE
Refactor normalizer methods to use PyTorch tensors avoiding numpy

### DIFF
--- a/amp_rsl_rl/algorithms/amp_ppo.py
+++ b/amp_rsl_rl/algorithms/amp_ppo.py
@@ -482,18 +482,10 @@ class AMP_PPO:
             # Normalize AMP observations if a normalizer is provided.
             if self.amp_normalizer is not None:
                 with torch.no_grad():
-                    policy_state = self.amp_normalizer.normalize_torch(
-                        policy_state, self.device
-                    )
-                    policy_next_state = self.amp_normalizer.normalize_torch(
-                        policy_next_state, self.device
-                    )
-                    expert_state = self.amp_normalizer.normalize_torch(
-                        expert_state, self.device
-                    )
-                    expert_next_state = self.amp_normalizer.normalize_torch(
-                        expert_next_state, self.device
-                    )
+                    policy_state = self.amp_normalizer.normalize(policy_state)
+                    policy_next_state = self.amp_normalizer.normalize(policy_next_state)
+                    expert_state = self.amp_normalizer.normalize(expert_state)
+                    expert_next_state = self.amp_normalizer.normalize(expert_next_state)
 
             # Pass concatenated state transitions to the discriminator.
             policy_d = self.discriminator(
@@ -526,8 +518,8 @@ class AMP_PPO:
 
             # Update the normalizer with current policy and expert AMP observations.
             if self.amp_normalizer is not None:
-                self.amp_normalizer.update(policy_state.cpu().numpy())
-                self.amp_normalizer.update(expert_state.cpu().numpy())
+                self.amp_normalizer.update(policy_state)
+                self.amp_normalizer.update(expert_state)
 
             # Compute probabilities from the discriminator logits.
             policy_d_prob = torch.sigmoid(policy_d)

--- a/amp_rsl_rl/networks/discriminator.py
+++ b/amp_rsl_rl/networks/discriminator.py
@@ -116,8 +116,8 @@ class Discriminator(nn.Module):
         """
         with torch.no_grad():
             if normalizer is not None:
-                state = normalizer.normalize_torch(state, self.device)
-                next_state = normalizer.normalize_torch(next_state, self.device)
+                state = normalizer.normalize(state)
+                next_state = normalizer.normalize(next_state)
 
             d = self.forward(torch.cat([state, next_state], dim=-1))
             reward = torch.clamp(1 - (1 / 4) * torch.square(d - 1), min=0)
@@ -142,8 +142,8 @@ class Discriminator(nn.Module):
         """
         with torch.no_grad():
             if normalizer is not None:
-                state = normalizer.normalize_torch(state, self.device)
-                next_state = normalizer.normalize_torch(next_state, self.device)
+                state = normalizer.normalize(state)
+                next_state = normalizer.normalize(next_state)
 
             discriminator_logit = self.forward(torch.cat([state, next_state], dim=-1))
             prob = torch.sigmoid(discriminator_logit)

--- a/amp_rsl_rl/runners/amp_on_policy_runner.py
+++ b/amp_rsl_rl/runners/amp_on_policy_runner.py
@@ -166,7 +166,7 @@ class AMPOnPolicyRunner:
         # self.env.unwrapped.scene["robot"].joint_names)
 
         # amp_data = AMPLoader(num_amp_obs, self.device)
-        self.amp_normalizer = Normalizer(num_amp_obs)
+        self.amp_normalizer = Normalizer(num_amp_obs, device=self.device)
         self.discriminator = Discriminator(
             num_amp_obs
             * 2,  # the discriminator takes in the concatenation of the current and next observation

--- a/benchmarking/benchmark_normalizer.py
+++ b/benchmarking/benchmark_normalizer.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+# benchmark_normalizer.py
+# Copyright (c) 2025, Istituto Italiano di Tecnologia
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+import time
+import torch
+from amp_rsl_rl.utils import Normalizer
+
+# =============================================
+# CONFIGURATION
+# =============================================
+device_str = "cuda" if torch.cuda.is_available() else "cpu"
+input_dim = 60  # total feature dimension (e.g. obs_dim)
+batch_size = 4096
+num_batches = 200  # how many batches to run
+epsilon = 1e-4
+clip_obs = 10.0
+
+
+def main():
+    device = torch.device(device_str)
+    print(f"Running on device: {device}")
+
+    # Initialize the normalizer
+    norm = Normalizer(
+        input_dim=input_dim,
+        epsilon=epsilon,
+        clip_obs=clip_obs,
+        device=device,
+    )
+
+    # Warm up CUDA
+    dummy = torch.randn(batch_size, input_dim, device=device)
+    for _ in range(5):
+        _ = norm.normalize(dummy)
+        norm.update(dummy)
+
+    # Benchmark normalize()
+    torch.cuda.synchronize()
+    t0 = time.perf_counter()
+    for _ in range(num_batches):
+        _ = norm.normalize(dummy)
+    torch.cuda.synchronize()
+    t1 = time.perf_counter()
+    total_elems = batch_size * num_batches
+    norm_throughput = total_elems / (t1 - t0)
+    print(f"[normalize] Throughput: {norm_throughput/1e6:.2f}M elements/s")
+
+    # Benchmark update()
+    torch.cuda.synchronize()
+    t2 = time.perf_counter()
+    for _ in range(num_batches):
+        norm.update(dummy)
+    torch.cuda.synchronize()
+    t3 = time.perf_counter()
+    update_throughput = total_elems / (t3 - t2)
+    print(f"[update  ] Throughput: {update_throughput/1e6:.2f}M elements/s")
+
+    # Combined normalize+update
+    torch.cuda.synchronize()
+    t4 = time.perf_counter()
+    for _ in range(num_batches):
+        y = norm.normalize(dummy)
+        norm.update(dummy)
+    torch.cuda.synchronize()
+    t5 = time.perf_counter()
+    combined_throughput = total_elems / (t5 - t4)
+    print(f"[total   ] Throughput: {combined_throughput/1e6:.2f}M elements/s")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This pull request refactors the `Normalizer` and `RunningMeanStd` classes to use PyTorch tensors instead of NumPy, enabling GPU support and improving performance and consistency across the repo. Redundant methods like `normalize_torch` have been removed, and normalization logic is now unified in a single `normalize` method. All dependent modules have been updated to use the new API and avoid unnecessary tensor-to-NumPy conversions. A benchmarking script was also added to evaluate performance, showing substantial improvements:

**Before (CUDA):**  
- normalize: 2.42M elements/s  
- update: 4.46M elements/s  
- total: 1.68M elements/s

**After (CUDA):**  
- normalize: 78.11M elements/s  
- update: 14.11M elements/s  
- total: 11.53M elements/s
