### PR TITLE
Refactor ReplayBuffer to to use PyTorch tensors avoiding numpy

### DIFF
--- a/amp_rsl_rl/storage/replay_buffer.py
+++ b/amp_rsl_rl/storage/replay_buffer.py
@@ -3,10 +3,8 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-
 import torch
-import numpy as np
-from typing import Generator, Tuple
+from typing import Generator, Tuple, Union
 
 
 class ReplayBuffer:
@@ -17,29 +15,44 @@ class ReplayBuffer:
         states (Tensor): Buffer of current states.
         next_states (Tensor): Buffer of next states.
         buffer_size (int): Maximum number of elements in the buffer.
-        device (str): Device where tensors are stored.
+        device (str or torch.device): Device where tensors are stored.
         step (int): Current write index.
         num_samples (int): Total number of inserted samples (up to buffer_size).
     """
 
-    def __init__(self, obs_dim: int, buffer_size: int, device: str) -> None:
+    def __init__(
+        self,
+        obs_dim: int,
+        buffer_size: int,
+        device: Union[str, torch.device] = "cpu",
+    ) -> None:
         """
         Initialize a ReplayBuffer object.
 
         Args:
             obs_dim (int): Dimension of the observation space.
             buffer_size (int): Maximum number of transitions to store.
-            device (str): Torch device where buffers are allocated ('cpu' or 'cuda').
+            device (str or torch.device): Torch device where buffers are allocated ('cpu' or 'cuda').
         """
-        self.states = torch.zeros(buffer_size, obs_dim).to(device)
-        self.next_states = torch.zeros(buffer_size, obs_dim).to(device)
+        self.device = torch.device(device)
         self.buffer_size = buffer_size
-        self.device = device
+
+        # Pre-allocate buffers on the target device
+        self.states = torch.zeros(
+            (buffer_size, obs_dim), dtype=torch.float32, device=self.device
+        )
+        self.next_states = torch.zeros(
+            (buffer_size, obs_dim), dtype=torch.float32, device=self.device
+        )
 
         self.step = 0
         self.num_samples = 0
 
-    def insert(self, states: torch.Tensor, next_states: torch.Tensor) -> None:
+    def insert(
+        self,
+        states: torch.Tensor,
+        next_states: torch.Tensor,
+    ) -> None:
         """
         Add a batch of states and next_states to the buffer.
 
@@ -47,26 +60,33 @@ class ReplayBuffer:
             states (Tensor): Batch of current states (batch_size, obs_dim).
             next_states (Tensor): Batch of next states (batch_size, obs_dim).
         """
-        num_states = states.shape[0]
-        start_idx = self.step
-        end_idx = self.step + num_states
+        # Move incoming data to buffer device if necessary
+        states = states.to(self.device)
+        next_states = next_states.to(self.device)
 
-        if end_idx > self.buffer_size:
-            # Wrap around the buffer end
-            upper_len = self.buffer_size - self.step
-            self.states[self.step : self.buffer_size] = states[:upper_len]
-            self.next_states[self.step : self.buffer_size] = next_states[:upper_len]
-            self.states[: end_idx - self.buffer_size] = states[upper_len:]
-            self.next_states[: end_idx - self.buffer_size] = next_states[upper_len:]
+        batch_size = states.shape[0]
+        end = self.step + batch_size
+
+        if end <= self.buffer_size:
+            self.states[self.step : end] = states
+            self.next_states[self.step : end] = next_states
         else:
-            self.states[start_idx:end_idx] = states
-            self.next_states[start_idx:end_idx] = next_states
+            # Wrap around
+            first_part = self.buffer_size - self.step
+            self.states[self.step :] = states[:first_part]
+            self.next_states[self.step :] = next_states[:first_part]
+            remainder = batch_size - first_part
+            self.states[:remainder] = states[first_part:]
+            self.next_states[:remainder] = next_states[first_part:]
 
-        self.num_samples = min(self.buffer_size, max(end_idx, self.num_samples))
-        self.step = (self.step + num_states) % self.buffer_size
+        # Update pointers
+        self.step = end % self.buffer_size
+        self.num_samples = min(self.buffer_size, self.num_samples + batch_size)
 
     def feed_forward_generator(
-        self, num_mini_batch: int, mini_batch_size: int
+        self,
+        num_mini_batch: int,
+        mini_batch_size: int,
     ) -> Generator[Tuple[torch.Tensor, torch.Tensor], None, None]:
         """
         Yield mini-batches of (state, next_state) tuples from the buffer.
@@ -78,11 +98,20 @@ class ReplayBuffer:
         Yields:
             Tuple[Tensor, Tensor]: A mini-batch of states and next_states.
         """
-        for _ in range(num_mini_batch):
-            sample_idxs = np.random.choice(
-                self.num_samples, size=mini_batch_size, replace=False
-            )
-            yield (
-                self.states[sample_idxs].to(self.device),
-                self.next_states[sample_idxs].to(self.device),
-            )
+        total = num_mini_batch * mini_batch_size
+        assert (
+            total <= self.num_samples
+        ), f"Not enough samples in buffer: requested {total}, but have {self.num_samples}"
+
+        # Generate a random permutation of valid indices on-device
+        indices = torch.randperm(self.num_samples, device=self.device)[:total]
+
+        for i in range(num_mini_batch):
+            batch_idx = indices[i * mini_batch_size : (i + 1) * mini_batch_size]
+            yield self.states[batch_idx], self.next_states[batch_idx]
+
+    def __len__(self) -> int:
+        """
+        Return the number of valid samples currently stored in the buffer.
+        """
+        return self.num_samples

--- a/benchmarking/benchmark_replay_buffer.py
+++ b/benchmarking/benchmark_replay_buffer.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+# benchmark_replay_buffer.py
+# Copyright (c) 2025, Istituto Italiano di Tecnologia
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+import time
+import torch
+from amp_rsl_rl.storage.replay_buffer import ReplayBuffer
+
+# =============================================
+# CONFIGURATION
+# =============================================
+device_str = "cuda" if torch.cuda.is_available() else "cpu"
+obs_dim = 60  # dimension of each state vector
+buffer_size = 200_000  # capacity of the circular buffer
+insert_batch = 4096  # how many transitions per insert() call
+num_inserts = 50  # how many insert() calls to benchmark
+mini_batch_size = 1024  # size of each sampled mini-batch
+num_mini_batches = 20  # how many mini-batches to sample
+
+
+def main():
+    device = torch.device(device_str)
+    print(f"\n[ReplayBuffer Benchmark] Device: {device}\n")
+
+    # 1) Initialize buffer
+    buf = ReplayBuffer(obs_dim, buffer_size, device)
+
+    # 2) Prepare dummy data
+    dummy_states = torch.randn(insert_batch, obs_dim, device=device)
+    dummy_next = torch.randn(insert_batch, obs_dim, device=device)
+
+    # Warm up (GPU kernels, caches, etc.)
+    for _ in range(5):
+        buf.insert(dummy_states, dummy_next)
+        for _ in buf.feed_forward_generator(1, mini_batch_size):
+            pass
+
+    # 3) Benchmark insert()
+    torch.cuda.synchronize()
+    t0 = time.perf_counter()
+    for _ in range(num_inserts):
+        buf.insert(dummy_states, dummy_next)
+    torch.cuda.synchronize()
+    t1 = time.perf_counter()
+
+    total_inserted = insert_batch * num_inserts
+    insert_rate = total_inserted / (t1 - t0)
+    print(
+        f"[insert] Inserted {total_inserted} samples in {(t1 - t0)*1e3:.1f} ms → "
+        f"{insert_rate:,.0f} samples/s"
+    )
+
+    # Ensure there's enough data to sample
+    assert len(buf) >= mini_batch_size * num_mini_batches, (
+        f"Need at least {mini_batch_size * num_mini_batches} samples, "
+        f"but buffer has only {len(buf)}"
+    )
+
+    # 4) Benchmark sampling
+    torch.cuda.synchronize()
+    t2 = time.perf_counter()
+    sampled = 0
+    for states, next_states in buf.feed_forward_generator(
+        num_mini_batches, mini_batch_size
+    ):
+        sampled += states.size(0)
+    torch.cuda.synchronize()
+    t3 = time.perf_counter()
+
+    sample_rate = sampled / (t3 - t2)
+    print(
+        f"[sample]  Sampled {sampled} samples in {(t3 - t2)*1e3:.1f} ms → "
+        f"{sample_rate:,.0f} samples/s"
+    )
+
+    # 5) Combined insert + sample
+    torch.cuda.synchronize()
+    t4 = time.perf_counter()
+    ops = 0
+    for _ in range(num_inserts):
+        buf.insert(dummy_states, dummy_next)
+        for states, _ in buf.feed_forward_generator(1, mini_batch_size):
+            ops += states.size(0)
+    torch.cuda.synchronize()
+    t5 = time.perf_counter()
+
+    combined_rate = (total_inserted + ops) / (t5 - t4)
+    print(
+        f"[combined] insert+sample of {total_inserted + ops} ops in {(t5 - t4)*1e3:.1f} ms → "
+        f"{combined_rate:,.0f} ops/s\n"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarking/benchmark_replay_buffer.py
+++ b/benchmarking/benchmark_replay_buffer.py
@@ -39,11 +39,13 @@ def main():
             pass
 
     # 3) Benchmark insert()
-    torch.cuda.synchronize()
+    if torch.cuda.is_available():
+        torch.cuda.synchronize()
     t0 = time.perf_counter()
     for _ in range(num_inserts):
         buf.insert(dummy_states, dummy_next)
-    torch.cuda.synchronize()
+    if torch.cuda.is_available():
+        torch.cuda.synchronize()
     t1 = time.perf_counter()
 
     total_inserted = insert_batch * num_inserts


### PR DESCRIPTION
This pull request improves the `ReplayBuffer` class for better performance, and introduces a benchmarking script to evaluate its efficiency. The buffer now accepts both `str` and `torch.device` for device selection, and all operations are performed directly on the specified device.

The main updates include optimized batched insertion with proper device handling, and a faster sampling implementation using `torch.randperm` instead of NumPy. The `feed_forward_generator` now includes validation to ensure enough samples are available, and sampling is fully on-device for better performance.

A new benchmarking script measures throughput and timing for insertion, sampling, and combined operations. Results demonstrate significant performance gains:

**Before (CUDA):**  
- **Insert:** 204,800 samples in **1.6 ms** → **127.5M samples/s**  
- **Sample:** 20,480 samples in **85.2 ms** → **240K samples/s**  
- **Combined:** 256,000 ops in **157.8 ms** → **1.62M ops/s**

**After (CUDA):**  
- **Insert:** 204,800 samples in **1.6 ms** → **128.0M samples/s**  
- **Sample:** 20,480 samples in **1.1 ms** → **19.3M samples/s**  
- **Combined:** 256,000 ops in **25.9 ms** → **9.88M ops/s**
