### PR TITLE
Add exponential policy ratio clamping on value loss

### DIFF
--- a/amp_rsl_rl/algorithms/amp_ppo.py
+++ b/amp_rsl_rl/algorithms/amp_ppo.py
@@ -59,6 +59,8 @@ class AMP_PPO:
         Maximum gradient norm for clipping gradients during backpropagation.
     use_clipped_value_loss : bool, default=True
         Flag indicating whether to use a clipped value loss, as in the original PPO implementation.
+    use_smooth_clamping : bool, default=False
+        Flag indicating whether to use exponential clamping on the value loos.
     schedule : str, default="fixed"
         Learning rate schedule mode ("fixed" or "adaptive" based on KL divergence).
     desired_kl : float, default=0.01
@@ -90,6 +92,7 @@ class AMP_PPO:
         schedule: str = "fixed",
         desired_kl: float = 0.01,
         amp_replay_buffer_size: int = 100000,
+        use_smooth_clamping: bool = False,
         device: str = "cpu",
     ) -> None:
         # Set device and learning hyperparameters
@@ -146,6 +149,7 @@ class AMP_PPO:
         self.lam: float = lam
         self.max_grad_norm: float = max_grad_norm
         self.use_clipped_value_loss: bool = use_clipped_value_loss
+        self.use_smooth_clamped_loss = use_smooth_clamped_loss
 
     def init_storage(
         self,
@@ -451,10 +455,22 @@ class AMP_PPO:
             ratio = torch.exp(
                 actions_log_prob_batch - torch.squeeze(old_actions_log_prob_batch)
             )
+
+            min_ = 1.0 - self.clip_param
+            max_ = 1.0 + self.clip_param
+
+            if self.use_smooth_clamping:
+                clipped_ratio = (
+                    1
+                    / (1 + torch.exp((-(ratio - min_) / (max_ - min_) + 0.5) * 4))
+                    * (max_ - min_)
+                    + min_
+                )
+            else:
+                clipped_ratio = torch.clamp(ratio, min_, max_)
+
             surrogate = -torch.squeeze(advantages_batch) * ratio
-            surrogate_clipped = -torch.squeeze(advantages_batch) * torch.clamp(
-                ratio, 1.0 - self.clip_param, 1.0 + self.clip_param
-            )
+            surrogate_clipped = -torch.squeeze(advantages_batch) * clipped_ratio
             surrogate_loss = torch.max(surrogate, surrogate_clipped).mean()
 
             # Compute the value function loss.


### PR DESCRIPTION
This pull request introduces a new feature to the `AMP_PPO` class in the `amp_rsl_rl` library, enabling the use of smooth clamping for value loss during training.

* **Added `use_smooth_clamping` parameter**:
  - Introduced a new boolean parameter, `use_smooth_clamping`, to the `AMP_PPO` class. This parameter allows users to enable or disable smooth clamping for value loss. It is set to `False` by default. (`amp_rsl_rl/algorithms/amp_ppo.py`: [[1]](diffhunk://#diff-235ac3de6d64a9036932fae009d8fd9e0c956b3d61818382c4df2b877118b678R62-R63) [[2]](diffhunk://#diff-235ac3de6d64a9036932fae009d8fd9e0c956b3d61818382c4df2b877118b678R95)
  - Added `self.use_smooth_clamped_loss` to the class's internal state to store the parameter value. (`amp_rsl_rl/algorithms/amp_ppo.py`: [amp_rsl_rl/algorithms/amp_ppo.pyR152](diffhunk://#diff-235ac3de6d64a9036932fae009d8fd9e0c956b3d61818382c4df2b877118b678R152))

* **Modified the `update` method**:
  - Introduced smooth clamping logic using an exponential function to compute `clipped_ratio` when `use_smooth_clamping` is enabled.
  - Retained the original clamping logic as a fallback when `use_smooth_clamping` is disabled.
  - Adjusted the computation of `surrogate_clipped` and the overall surrogate loss to incorporate the new clamping logic. (`amp_rsl_rl/algorithms/amp_ppo.py`: [amp_rsl_rl/algorithms/amp_ppo.pyL454-R473](diffhunk://#diff-235ac3de6d64a9036932fae009d8fd9e0c956b3d61818382c4df2b877118b678L454-R473))