### PR TITLE
Enhance ReplayBuffer's feed_forward_generator to support sampling with replacement

### DIFF
--- a/amp_rsl_rl/algorithms/amp_ppo.py
+++ b/amp_rsl_rl/algorithms/amp_ppo.py
@@ -376,10 +376,11 @@ class AMP_PPO:
 
         # Generator for policy-generated AMP transitions.
         amp_policy_generator = self.amp_storage.feed_forward_generator(
-            self.num_learning_epochs * self.num_mini_batches,
-            self.storage.num_envs
+            num_mini_batch=self.num_learning_epochs * self.num_mini_batches,
+            mini_batch_size=self.storage.num_envs
             * self.storage.num_transitions_per_env
             // self.num_mini_batches,
+            replace_if_needed=True,
         )
 
         # Generator for expert AMP data.


### PR DESCRIPTION
This PR reintroduces a feature removed in #12 Indeed, when I tried to run a training, I got 
```
I got AssertionError: Not enough samples in buffer: requested 655360, but have 100000
```

Since the insertions might be lower than the requested sample, I added the possibility to resample the same data point