### PR TITLE
Support optional dataset downloading from Hugging Face with caching

### DIFF
--- a/amp_rsl_rl/runners/amp_on_policy_runner.py
+++ b/amp_rsl_rl/runners/amp_on_policy_runner.py
@@ -154,13 +154,16 @@ class AMPOnPolicyRunner:
         # Initilize all the ingredients required for AMP (discriminator, dataset loader)
         num_amp_obs = extras["observations"]["amp"].shape[1]
         amp_data = AMPLoader(
-            self.device,
-            self.cfg["amp_data_path"],
-            self.cfg["dataset_names"],
-            self.cfg["dataset_weights"],
-            delta_t,
-            self.cfg["slow_down_factor"],
-            actuated_joint_names,
+            device=self.device,
+            dataset_path_root=self.cfg.get("amp_data_path", None),
+            dataset_names=self.cfg["dataset_names"],
+            dataset_weights=self.cfg["dataset_weights"],
+            simulation_dt=delta_t,
+            slow_down_factor=self.cfg["slow_down_factor"],
+            expected_joint_names=actuated_joint_names,
+            download_from_hf=self.cfg.get("download_from_hf", False),
+            robot_folder=self.cfg.get("robot_folder", None),
+            repo_id=self.cfg.get("repo_id", None),
         )
 
         # self.env.unwrapped.scene["robot"].joint_names)

--- a/amp_rsl_rl/utils/motion_loader.py
+++ b/amp_rsl_rl/utils/motion_loader.py
@@ -197,7 +197,7 @@ class AMPLoader:
         dataset_weights: List[float],
         simulation_dt: float,
         slow_down_factor: int,
-        dataset_path_root: Optional[str, Path] = None,
+        dataset_path_root: Optional[Union[str, Path]] = None,
         expected_joint_names: Optional[List[str]] = None,
         download_from_hf: Optional[bool] = False,
         robot_folder: Optional[str] = "ergocub",

--- a/amp_rsl_rl/utils/motion_loader.py
+++ b/amp_rsl_rl/utils/motion_loader.py
@@ -209,15 +209,17 @@ class AMPLoader:
             print("Downloading datasets from Hugging Face.")
             if dataset_path_root is None:
                 print(
-                    "Warning: `dataset_path_root` is None."
-                    "A cache directory will be created."
+                    "Warning: `dataset_path_root` is None. "
+                    "A cache directory will be used."
                 )
 
                 # Create a cache directory for downloading
                 dataset_path_root = platformdirs.user_cache_path(
-                    appname="amp-rsl-rl", appauthor="ami-iit"
+                    appname="amp-rsl-rl",
+                    appauthor="ami-iit",
+                    ensure_exists=True,
                 )
-                print(f"Cache directory created at: {dataset_path_root}")
+                print(f"Cache directory: {dataset_path_root}")
 
             # Convert dataset path to Path object for easier handling
             dataset_path_root = Path(dataset_path_root)

--- a/amp_rsl_rl/utils/motion_loader.py
+++ b/amp_rsl_rl/utils/motion_loader.py
@@ -210,7 +210,7 @@ class AMPLoader:
             if dataset_path_root is None:
                 print(
                     "Warning: `dataset_path_root` is None."
-                    "Please specify a local path to avoid downloading every time."
+                    "A cache directory will be created."
                 )
 
                 # Create a cache directory for downloading

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ classifiers = [  # Added standard PyPI classifiers
 keywords = ["reinforcement-learning", "robotics", "motion-priors", "ppo"]
 dependencies = [
     "numpy>=1.21.0",
+    "platformdirs>=4.0.0",
     "scipy>=1.7.0",
     "torch>=1.10.0",
     "rsl-rl-lib>=2.3.0",


### PR DESCRIPTION
This pull request introduces enhancements to the AMP loader by adding support for downloading datasets from Hugging Face using the login in https://github.com/ami-iit/amp-rsl-rl/blob/main/example/load_amp_dataset.py. The changes primarily focus on extending the `AMPLoader` class and its integration, along with minor updates to dependencies.

### Enhancements to AMP functionality:

* [`amp_rsl_rl/runners/amp_on_policy_runner.py`](diffhunk://#diff-4b60014cb1f62243b3329a87dc493f380de995f58860d82b211f25a1418009f2L157-R166): Updated the initialization of `AMPLoader` to include new parameters such as `download_from_hf`, `robot_folder`, and `repo_id`, enabling dataset downloads from Hugging Face.
* [`amp_rsl_rl/utils/motion_loader.py`](diffhunk://#diff-c8064b1baa437252509b1b8995c0fce59c5295e107e7a479381c351ae25b3620R188-R232): Modified the `AMPLoader` class to support optional parameters for downloading datasets from Hugging Face, including handling cache directories and repository details. Added a fallback to create a cache directory using `platformdirs` if `dataset_path_root` is not provided.

### Dependency updates:

* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R35): Added `platformdirs>=4.0.0` to dependencies for managing cache directories required by the new Hugging Face dataset download functionality.

### Minor improvements:

* [`amp_rsl_rl/utils/motion_loader.py`](diffhunk://#diff-c8064b1baa437252509b1b8995c0fce59c5295e107e7a479381c351ae25b3620L5-R11): Added `Optional` to type hints for better clarity and flexibility in function signatures.