### PR TITLE
Allow loading saved policies on CPU

### DIFF
--- a/amp_rsl_rl/runners/amp_on_policy_runner.py
+++ b/amp_rsl_rl/runners/amp_on_policy_runner.py
@@ -602,7 +602,7 @@ class AMPOnPolicyRunner:
                 )
 
     def load(self, path, load_optimizer=True):
-        loaded_dict = torch.load(path)
+        loaded_dict = torch.load(path, map_location=self.device, weights_only=False)
         self.alg.actor_critic.load_state_dict(loaded_dict["model_state_dict"])
         self.alg.discriminator.load_state_dict(loaded_dict["discriminator_state_dict"])
         self.alg.amp_normalizer = loaded_dict["amp_normalizer"]

--- a/amp_rsl_rl/runners/amp_on_policy_runner.py
+++ b/amp_rsl_rl/runners/amp_on_policy_runner.py
@@ -601,8 +601,8 @@ class AMPOnPolicyRunner:
                     self.current_learning_iteration,
                 )
 
-    def load(self, path, load_optimizer=True):
-        loaded_dict = torch.load(path, map_location=self.device, weights_only=False)
+    def load(self, path, load_optimizer=True, weights_only=False):
+        loaded_dict = torch.load(path, map_location=self.device, weights_only=weights_only)
         self.alg.actor_critic.load_state_dict(loaded_dict["model_state_dict"])
         self.alg.discriminator.load_state_dict(loaded_dict["discriminator_state_dict"])
         self.alg.amp_normalizer = loaded_dict["amp_normalizer"]


### PR DESCRIPTION
This pull request includes a minor update to the `load` method in the `amp_on_policy_runner.py` file to enhance compatibility with device-specific loading and provide an option to load weights only.

* [`amp_rsl_rl/runners/amp_on_policy_runner.py`](diffhunk://#diff-4b60014cb1f62243b3329a87dc493f380de995f58860d82b211f25a1418009f2L605-R605): Updated the `torch.load` call in the `load` method to include the `map_location` parameter for device-specific loading and added the `weights_only` argument to resolve a PyTorch error while loading model weights.