### PR TITLE
Add angular velocity derivative computation to AMPLoader

### DIFF
--- a/amp_rsl_rl/utils/motion_loader.py
+++ b/amp_rsl_rl/utils/motion_loader.py
@@ -281,6 +281,27 @@ class AMPLoader:
         slerp = Slerp(original_keyframes, tmp)
         return slerp(target_keyframes)
 
+    def _compute_ang_vel_derivative(
+        self,
+        data: List[Rotation],
+        dt: float,
+        local: bool = False,
+    ) -> np.ndarray:
+        R_prev = data[:-1]
+        R_next = data[1:]
+
+        if local:
+            # ΔR_body = R_i⁻¹ · R_{i+1}
+            rel = R_prev.inv() * R_next
+        else:
+            # ΔR_inertial = R_{i+1} · R_i⁻¹
+            rel = R_next * R_prev.inv()
+
+        # Log-map to rotation vectors and divide by Δt
+        rotvec = rel.as_rotvec() / dt
+
+        return np.vstack((rotvec, rotvec[-1]))
+
     def _compute_raw_derivative(self, data: np.ndarray, dt: float) -> np.ndarray:
         d = (data[1:] - data[:-1]) / dt
         return np.vstack([d, d[-1:]])
@@ -339,6 +360,11 @@ class AMPLoader:
         resampled_base_lin_vel_mixed = self._compute_raw_derivative(
             resampled_base_positions, simulation_dt
         )
+
+        resampled_base_ang_vel_mixed = self._compute_ang_vel_derivative(
+            resampled_base_orientations, simulation_dt, local=False
+        )
+
         resampled_base_lin_vel_local = np.stack(
             [
                 R.as_matrix().T @ v
@@ -347,15 +373,17 @@ class AMPLoader:
                 )
             ]
         )
-        zeros = np.zeros_like(resampled_base_lin_vel_mixed)
+        resampled_base_ang_vel_local = self._compute_ang_vel_derivative(
+            resampled_base_orientations, simulation_dt, local=True
+        )
 
         return MotionData(
             joint_positions=resampled_joint_positions,
             joint_velocities=resampled_joint_velocities,
             base_lin_velocities_mixed=resampled_base_lin_vel_mixed,
-            base_ang_velocities_mixed=zeros,
+            base_ang_velocities_mixed=resampled_base_ang_vel_mixed,
             base_lin_velocities_local=resampled_base_lin_vel_local,
-            base_ang_velocities_local=zeros,
+            base_ang_velocities_local=resampled_base_ang_vel_local,
             base_quat=resampled_base_orientations,
             device=self.device,
         )


### PR DESCRIPTION
This pull request enhances the `motion_loader.py` utility by introducing a new method to compute angular velocity derivatives and integrating it into the motion data loading process.

### Enhancements to angular velocity computation:

* **New method `_compute_ang_vel_derivative`:** Added a helper function to compute angular velocity derivatives based on rotation data. It supports both local and inertial frames, using the log-map of relative rotations divided by the timestep `dt`.

* **Integration into `load_data`:** Incorporated `_compute_ang_vel_derivative` to compute and assign angular velocities for both mixed and local frames (`resampled_base_ang_vel_mixed` and `resampled_base_ang_vel_local`), replacing the placeholder zero arrays. [[1]](diffhunk://#diff-c8064b1baa437252509b1b8995c0fce59c5295e107e7a479381c351ae25b3620R363-R367) [[2]](diffhunk://#diff-c8064b1baa437252509b1b8995c0fce59c5295e107e7a479381c351ae25b3620L350-R386)