### PR TITLE
Compute discriminator output with policy and expert states

### DIFF
--- a/amp_rsl_rl/algorithms/amp_ppo.py
+++ b/amp_rsl_rl/algorithms/amp_ppo.py
@@ -104,6 +104,7 @@ class AMP_PPO:
         # Set up the discriminator and move it to the appropriate device.
         self.discriminator: Discriminator = discriminator.to(self.device)
         self.amp_transition: RolloutStorage.Transition = RolloutStorage.Transition()
+        self.discriminator_loss = torch.nn.BCEWithLogitsLoss()
 
         # Determine observation dimension used in the replay buffer.
         # The discriminator expects concatenated observations, so the replay buffer uses half the dimension.
@@ -503,12 +504,19 @@ class AMP_PPO:
                     expert_state = self.amp_normalizer.normalize(expert_state)
                     expert_next_state = self.amp_normalizer.normalize(expert_next_state)
 
-            # Pass concatenated state transitions to the discriminator.
-            policy_d = self.discriminator(
-                torch.cat([policy_state, policy_next_state], dim=-1)
+            # Concatenate policy and expert AMP observations for the discriminator input.
+            B_pol = policy_state.size(0)
+            discriminator_input = torch.cat(
+                (
+                    torch.cat([policy_state, policy_next_state], dim=-1),
+                    torch.cat([expert_state, expert_next_state], dim=-1),
+                ),
+                dim=0,
             )
-            expert_d = self.discriminator(
-                torch.cat([expert_state, expert_next_state], dim=-1)
+            discriminator_output = self.discriminator(discriminator_input)
+            policy_d, expert_d = (
+                discriminator_output[:B_pol],
+                discriminator_output[B_pol:],
             )
 
             # Compute discriminator losses for expert and policy data.

--- a/amp_rsl_rl/algorithms/amp_ppo.py
+++ b/amp_rsl_rl/algorithms/amp_ppo.py
@@ -318,9 +318,8 @@ class AMP_PPO:
         torch.Tensor
             The computed policy loss.
         """
-        loss_fn = torch.nn.BCEWithLogitsLoss()
         expected = torch.zeros_like(discriminator_output).to(self.device)
-        return loss_fn(discriminator_output, expected)
+        return self.discriminator_loss(discriminator_output, expected)
 
     def discriminator_expert_loss(
         self, discriminator_output: torch.Tensor
@@ -339,9 +338,8 @@ class AMP_PPO:
         torch.Tensor
             The computed expert loss.
         """
-        loss_fn = torch.nn.BCEWithLogitsLoss()
         expected = torch.ones_like(discriminator_output).to(self.device)
-        return loss_fn(discriminator_output, expected)
+        return self.discriminator_loss(discriminator_output, expected)
 
     def update(self) -> Tuple[float, float, float, float, float, float, float, float]:
         """

--- a/amp_rsl_rl/algorithms/amp_ppo.py
+++ b/amp_rsl_rl/algorithms/amp_ppo.py
@@ -318,7 +318,7 @@ class AMP_PPO:
         torch.Tensor
             The computed policy loss.
         """
-        expected = torch.zeros_like(discriminator_output).to(self.device)
+        expected = torch.zeros_like(discriminator_output, device=self.device)
         return self.discriminator_loss(discriminator_output, expected)
 
     def discriminator_expert_loss(
@@ -338,7 +338,7 @@ class AMP_PPO:
         torch.Tensor
             The computed expert loss.
         """
-        expected = torch.ones_like(discriminator_output).to(self.device)
+        expected = torch.ones_like(discriminator_output, device=self.device)
         return self.discriminator_loss(discriminator_output, expected)
 
     def update(self) -> Tuple[float, float, float, float, float, float, float, float]:


### PR DESCRIPTION
Concatenate policy and expert observations for the discriminator input to enhance its performance. This change introduces a new loss function for the discriminator.