### PR TITLE
Add modified Wasserstein loss in the Discriminator

### DIFF
--- a/amp_rsl_rl/algorithms/amp_ppo.py
+++ b/amp_rsl_rl/algorithms/amp_ppo.py
@@ -104,8 +104,6 @@ class AMP_PPO:
         # Set up the discriminator and move it to the appropriate device.
         self.discriminator: Discriminator = discriminator.to(self.device)
         self.amp_transition: RolloutStorage.Transition = RolloutStorage.Transition()
-        self.discriminator_loss = torch.nn.BCEWithLogitsLoss()
-
         # Determine observation dimension used in the replay buffer.
         # The discriminator expects concatenated observations, so the replay buffer uses half the dimension.
         obs_dim: int = self.discriminator.input_dim // 2
@@ -301,46 +299,6 @@ class AMP_PPO:
         last_values = self.actor_critic.evaluate(last_critic_obs).detach()
         self.storage.compute_returns(last_values, self.gamma, self.lam)
 
-    def discriminator_policy_loss(
-        self, discriminator_output: torch.Tensor
-    ) -> torch.Tensor:
-        """
-        Computes the loss for the discriminator when classifying policy-generated transitions.
-        Uses binary cross-entropy loss where the target label for policy transitions is 0.
-
-        Parameters
-        ----------
-        discriminator_output : torch.Tensor
-            The raw logits output from the discriminator for policy data.
-
-        Returns
-        -------
-        torch.Tensor
-            The computed policy loss.
-        """
-        expected = torch.zeros_like(discriminator_output, device=self.device)
-        return self.discriminator_loss(discriminator_output, expected)
-
-    def discriminator_expert_loss(
-        self, discriminator_output: torch.Tensor
-    ) -> torch.Tensor:
-        """
-        Computes the loss for the discriminator when classifying expert transitions.
-        Uses binary cross-entropy loss where the target label for expert transitions is 1.
-
-        Parameters
-        ----------
-        discriminator_output : torch.Tensor
-            The raw logits output from the discriminator for expert data.
-
-        Returns
-        -------
-        torch.Tensor
-            The computed expert loss.
-        """
-        expected = torch.ones_like(discriminator_output, device=self.device)
-        return self.discriminator_loss(discriminator_output, expected)
-
     def update(self) -> Tuple[float, float, float, float, float, float, float, float]:
         """
         Performs a single update step for both the actor-critic (PPO) and the AMP discriminator.
@@ -517,16 +475,9 @@ class AMP_PPO:
                 discriminator_output[B_pol:],
             )
 
-            # Compute discriminator losses for expert and policy data.
-            expert_loss = self.discriminator_expert_loss(expert_d)
-            policy_loss = self.discriminator_policy_loss(policy_d)
-
-            # AMP loss is the average of expert and policy losses.
-            amp_loss = 0.5 * (expert_loss + policy_loss)
-
-            # Compute gradient penalty to stabilize discriminator training.
-            grad_pen_loss = self.discriminator.compute_grad_pen(
-                *sample_amp_expert, lambda_=10
+            # Compute discriminator losses
+            amp_loss, grad_pen_loss = self.discriminator.compute_loss(
+                policy_d, expert_d, sample_amp_expert, sample_amp_policy, lambda_=10
             )
 
             # The final loss combines the PPO loss with AMP losses.

--- a/amp_rsl_rl/networks/discriminator.py
+++ b/amp_rsl_rl/networks/discriminator.py
@@ -217,7 +217,6 @@ class Discriminator(nn.Module):
             retain_graph=True,
             only_inputs=True,
         )[0]
-        # return 1 * (grad.norm(2, dim=1) - offset).pow(2).mean()
         return lambda_ * (grad.norm(2, dim=1) - offset).pow(2).mean()
 
     def wgan_loss(self, policy_d, expert_d):

--- a/amp_rsl_rl/networks/discriminator.py
+++ b/amp_rsl_rl/networks/discriminator.py
@@ -101,8 +101,8 @@ class Discriminator(nn.Module):
             discriminator_logit = self.forward(torch.cat([state, next_state], dim=-1))
 
             if self.loss_type == "wgan":
-                discriminator_logit = torch.tanh(self.eta_wgan * discriminator_logit)
-                return torch.exp(self.reward_scale * discriminator_logit).squeeze()
+                discriminator_logit = torch.tanh(self.eta_wgan * discriminator_logit / discriminator_logit.std())
+                return self.reward_scale * torch.exp(discriminator_logit).squeeze()
 
             prob = torch.sigmoid(discriminator_logit)
             # Avoid log(0) by clamping the input to a minimum threshold

--- a/amp_rsl_rl/networks/discriminator.py
+++ b/amp_rsl_rl/networks/discriminator.py
@@ -29,6 +29,7 @@ class Discriminator(nn.Module):
         reward_scale: float,
         reward_clamp_epsilon: float = 0.0001,
         device: str = "cpu",
+        loss_type: str = "BCEWithLogits",
     ):
         super(Discriminator, self).__init__()
 
@@ -49,6 +50,17 @@ class Discriminator(nn.Module):
 
         self.trunk.train()
         self.linear.train()
+        loss_type = "wgan"
+        self.loss_type = loss_type
+        if loss_type == "BCEWithLogits":
+            self.loss_fun = torch.nn.BCEWithLogitsLoss()
+        elif loss_type == "wgan":
+            self.loss_fun = None
+        else:
+            raise ValueError(
+                f"Unsupported loss type: {loss_type}. Supported types are 'BCEWithLogits' and 'wgan'."
+            )
+        # self.loss_fun = torch.nn.BCEWithLogitsLoss()
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         """Forward pass through the discriminator.
@@ -63,39 +75,39 @@ class Discriminator(nn.Module):
         d = self.linear(h)
         return d
 
-    def compute_grad_pen(
-        self,
-        expert_state: torch.Tensor,
-        expert_next_state: torch.Tensor,
-        lambda_: float = 10,
-    ) -> torch.Tensor:
-        """Computes the gradient penalty used to regularize the discriminator.
+    # def compute_grad_pen(
+    #     self,
+    #     expert_state: torch.Tensor,
+    #     expert_next_state: torch.Tensor,
+    #     lambda_: float = 10,
+    # ) -> torch.Tensor:
+    #     """Computes the gradient penalty used to regularize the discriminator.
 
-        Args:
-            expert_state (Tensor): Batch of expert states.
-            expert_next_state (Tensor): Batch of expert next states.
-            lambda_ (float): Penalty coefficient.
+    #     Args:
+    #         expert_state (Tensor): Batch of expert states.
+    #         expert_next_state (Tensor): Batch of expert next states.
+    #         lambda_ (float): Penalty coefficient.
 
-        Returns:
-            Tensor: Gradient penalty value.
-        """
-        expert_data = torch.cat([expert_state, expert_next_state], dim=-1)
-        expert_data.requires_grad = True
+    #     Returns:
+    #         Tensor: Gradient penalty value.
+    #     """
+    #     expert_data = torch.cat([expert_state, expert_next_state], dim=-1)
+    #     expert_data.requires_grad = True
 
-        disc = self.forward(expert_data)
-        ones = torch.ones(disc.size(), device=disc.device)
+    #     disc = self.forward(expert_data)
+    #     ones = torch.ones(disc.size(), device=disc.device)
 
-        grad = autograd.grad(
-            outputs=disc,
-            inputs=expert_data,
-            grad_outputs=ones,
-            create_graph=True,
-            retain_graph=True,
-            only_inputs=True,
-        )[0]
+    #     grad = autograd.grad(
+    #         outputs=disc,
+    #         inputs=expert_data,
+    #         grad_outputs=ones,
+    #         create_graph=True,
+    #         retain_graph=True,
+    #         only_inputs=True,
+    #     )[0]
 
-        grad_pen = lambda_ * (grad.norm(2, dim=1) - 0).pow(2).mean()
-        return grad_pen
+    #     grad_pen = lambda_ * (grad.norm(2, dim=1) - 0).pow(2).mean()
+    #     return grad_pen
 
     def predict_reward(
         self,
@@ -119,8 +131,12 @@ class Discriminator(nn.Module):
                 next_state = normalizer.normalize(next_state)
 
             discriminator_logit = self.forward(torch.cat([state, next_state], dim=-1))
-            prob = torch.sigmoid(discriminator_logit)
 
+            if self.loss_type == "wgan":
+                # reward ∝  -D(x)  (policy wants to *raise* D)
+                return (self.reward_scale * discriminator_logit).squeeze()
+
+            prob = torch.sigmoid(discriminator_logit)
             # Avoid log(0) by clamping the input to a minimum threshold
             reward = -torch.log(
                 torch.maximum(
@@ -131,3 +147,123 @@ class Discriminator(nn.Module):
 
             reward = self.reward_scale * reward
             return reward.squeeze()
+
+    def policy_loss(self, discriminator_output: torch.Tensor) -> torch.Tensor:
+        """
+        Computes the loss for the discriminator when classifying policy-generated transitions.
+        Uses binary cross-entropy loss where the target label for policy transitions is 0.
+
+        Parameters
+        ----------
+        discriminator_output : torch.Tensor
+            The raw logits output from the discriminator for policy data.
+
+        Returns
+        -------
+        torch.Tensor
+            The computed policy loss.
+        """
+        expected = torch.zeros_like(discriminator_output, device=self.device)
+        return self.loss_fun(discriminator_output, expected)
+
+    def expert_loss(self, discriminator_output: torch.Tensor) -> torch.Tensor:
+        """
+        Computes the loss for the discriminator when classifying expert transitions.
+        Uses binary cross-entropy loss where the target label for expert transitions is 1.
+
+        Parameters
+        ----------
+        discriminator_output : torch.Tensor
+            The raw logits output from the discriminator for expert data.
+
+        Returns
+        -------
+        torch.Tensor
+            The computed expert loss.
+        """
+        expected = torch.ones_like(discriminator_output, device=self.device)
+        return self.loss_fun(discriminator_output, expected)
+
+    def compute_loss(
+        self, policy_d, expert_d, sample_amp_expert, sample_amp_policy=None
+    ):
+
+        # Compute gradient penalty to stabilize discriminator training.
+        grad_pen_loss = self.compute_grad_pen(
+            expert_states=sample_amp_expert,
+            policy_states=sample_amp_policy,
+            lambda_=10,
+        )
+        if self.loss_type == "BCEWithLogits":
+            expert_loss = self.loss_fun(expert_d, torch.ones_like(expert_d))
+            policy_loss = self.loss_fun(policy_d, torch.zeros_like(policy_d))
+            # AMP loss is the average of expert and policy losses.
+            amp_loss = 0.5 * (expert_loss + policy_loss)
+        elif self.loss_type == "wgan":
+            amp_loss = self.wgan_loss(
+                policy_d=policy_d, expert_d=expert_d
+            )
+        return amp_loss, grad_pen_loss
+
+    def compute_grad_pen(
+        self,
+        expert_states: tuple[torch.Tensor, torch.Tensor],
+        policy_states: tuple[torch.Tensor, torch.Tensor] = None,
+        lambda_: float = 10,
+    ) -> torch.Tensor:
+        """Computes the gradient penalty used to regularize the discriminator.
+
+        Args:
+            expert_state (Tensor): Batch of expert states.
+            expert_next_state (Tensor): Batch of expert next states.
+            lambda_ (float): Penalty coefficient.
+
+        Returns:
+            Tensor: Gradient penalty value.
+        """
+        expert = torch.cat(expert_states, -1)
+
+        if self.loss_type == "wgan":
+            policy = torch.cat(policy_states, -1)
+            alpha = torch.rand(expert.size(0), 1, device=expert.device)
+            data = alpha * expert + (1 - alpha) * policy
+            offset = 0
+        elif self.loss_type == "BCEWithLogits":
+            data = expert
+            offset = 1
+        else:
+            raise ValueError(
+                f"Unsupported loss type: {self.loss_type}. Supported types are 'BCEWithLogits' and 'wgan'."
+            )
+
+        data.requires_grad = True
+        scores = self.forward(data)
+        grad = autograd.grad(
+            outputs=scores,
+            inputs=data,
+            grad_outputs=torch.ones_like(scores),
+            create_graph=True,
+            retain_graph=True,
+            only_inputs=True,
+        )[0]
+
+        return lambda_ * (grad.norm(2, dim=1) - offset).pow(2).mean()
+
+    @staticmethod
+    def wgan_loss(policy_d, expert_d):
+        """
+        Wasserstein critic loss (to *minimize*):
+        Args:
+            policy_d (Tensor): Discriminator output for policy data.
+            expert_d (Tensor): Discriminator output for expert data.
+        """
+        return policy_d.mean() - expert_d.mean()
+
+    @staticmethod
+    def wgan_pi_loss(policy_d):
+        """
+        Wasserstein policy loss (to *maximize*):
+        Args:
+            policy_d (Tensor): Discriminator output for policy data.
+        """
+        return -policy_d.mean()

--- a/amp_rsl_rl/networks/discriminator.py
+++ b/amp_rsl_rl/networks/discriminator.py
@@ -184,8 +184,8 @@ class Discriminator(nn.Module):
         """Computes the gradient penalty used to regularize the discriminator.
 
         Args:
-            expert_state (Tensor): Batch of expert states.
-            expert_next_state (Tensor): Batch of expert next states.
+            expert_states (tuple[Tensor, Tensor]): A tuple containing batches of expert states and expert next states.
+            policy_states (tuple[Tensor, Tensor]): A tuple containing batches of policy states and policy next states.
             lambda_ (float): Penalty coefficient.
 
         Returns:

--- a/amp_rsl_rl/networks/discriminator.py
+++ b/amp_rsl_rl/networks/discriminator.py
@@ -62,7 +62,6 @@ class Discriminator(nn.Module):
             raise ValueError(
                 f"Unsupported loss type: {self.loss_type}. Supported types are 'BCEWithLogits' and 'Wasserstein'."
             )
-        # self.loss_fun = torch.nn.BCEWithLogitsLoss()
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         """Forward pass through the discriminator.

--- a/amp_rsl_rl/runners/amp_on_policy_runner.py
+++ b/amp_rsl_rl/runners/amp_on_policy_runner.py
@@ -168,11 +168,11 @@ class AMPOnPolicyRunner:
         # amp_data = AMPLoader(num_amp_obs, self.device)
         self.amp_normalizer = Normalizer(num_amp_obs, device=self.device)
         self.discriminator = Discriminator(
-            num_amp_obs
-            * 2,  # the discriminator takes in the concatenation of the current and next observation
-            self.discriminator_cfg["hidden_dims"],
-            self.discriminator_cfg["reward_scale"],
+            input_dim=num_amp_obs* 2,  # the discriminator takes in the concatenation of the current and next observation
+            hidden_layer_sizes=self.discriminator_cfg["hidden_dims"],
+            reward_scale=self.discriminator_cfg["reward_scale"],
             device=self.device,
+            loss_type=self.discriminator_cfg["loss_type"],
         ).to(self.device)
 
         # Initialize the PPO algorithm
@@ -610,7 +610,9 @@ class AMPOnPolicyRunner:
                 )
 
     def load(self, path, load_optimizer=True, weights_only=False):
-        loaded_dict = torch.load(path, map_location=self.device, weights_only=weights_only)
+        loaded_dict = torch.load(
+            path, map_location=self.device, weights_only=weights_only
+        )
         self.alg.actor_critic.load_state_dict(loaded_dict["model_state_dict"])
         self.alg.discriminator.load_state_dict(loaded_dict["discriminator_state_dict"])
         self.alg.amp_normalizer = loaded_dict["amp_normalizer"]


### PR DESCRIPTION
This pull request introduces support for a new loss type (Wasserstein loss). 

Note that the [Wasserstein GAN](https://en.wikipedia.org/wiki/Wasserstein_GAN) formulation minimizes as loss

$$
L = D(fake) - D(true).
$$

Empirically, I found out that if the last layer of the discriminator is a tanh(), the training is smoother and more stable. 

The reward is then

$$
r = w \cdot \text{exp}(\eta \cdot D(fake)).
$$

### AMP PPO Algorithm Updates:
* Removed redundant methods `discriminator_policy_loss` and `discriminator_expert_loss` from `amp_ppo.py`. Loss computation is now delegated to the `Discriminator` class for better encapsulation.
* Updated the `update` method in `amp_ppo.py` to use the new `compute_loss` method from the `Discriminator` class, simplifying the logic for AMP loss and gradient penalty computation.

### Discriminator Enhancements:
* Added support for a new loss type, "Wasserstein", alongside the existing "BCEWithLogits". Introduced parameters `loss_type` and `eta_wgan` in the `Discriminator` class to configure the loss function. [[1]](diffhunk://#diff-c269da6f7ef5d002e1b1683cd2edd9f582b14b6ef14b67a5c93d3bda9a6a712dR32-R33) [[2]](diffhunk://#diff-c269da6f7ef5d002e1b1683cd2edd9f582b14b6ef14b67a5c93d3bda9a6a712dR54-R65)
* Refactored the `Discriminator` class to include modular methods for `policy_loss`, `expert_loss`, and a unified `compute_loss` method. This centralizes loss computation and supports both loss types.
* Reintroduced and updated the `compute_grad_pen` method to handle gradient penalty computation for both BCE and Wasserstein loss types. Added a new `wgan_loss` method for Wasserstein loss.

### Runner Updates:
* Updated the `amp_on_policy_runner.py` to pass the `loss_type` configuration to the `Discriminator` during initialization, enabling runtime selection of the loss function.
* Minor formatting fix in the `load` method for improved readability.