### PR TITLE
Add  Mixture-of-Experts implementation

### DIFF
--- a/amp_rsl_rl/networks/__init__.py
+++ b/amp_rsl_rl/networks/__init__.py
@@ -7,7 +7,6 @@
 """Implementation of the network for the AMP algorithm."""
 
 from .discriminator import Discriminator
-from .ac_moe import ActorMoE
-from .ac_moe_old import ActorCriticMoE
+from .ac_moe import ActorMoE, ActorCriticMoE
 
 __all__ = ["Discriminator", "ActorCriticMoE", "ActorMoE"]

--- a/amp_rsl_rl/networks/__init__.py
+++ b/amp_rsl_rl/networks/__init__.py
@@ -7,5 +7,7 @@
 """Implementation of the network for the AMP algorithm."""
 
 from .discriminator import Discriminator
+from .ac_moe import ActorMoE
+from .ac_moe_old import ActorCriticMoE
 
-__all__ = ["Discriminator"]
+__all__ = ["Discriminator", "ActorCriticMoE", "ActorMoE"]

--- a/amp_rsl_rl/networks/ac_moe.py
+++ b/amp_rsl_rl/networks/ac_moe.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+import torch
+import torch.nn as nn
+from torch.distributions import Normal
+from rsl_rl.utils import resolve_nn_activation
+
+
+class MLP_net(nn.Sequential):
+    def __init__(self, in_dim, hidden_dims, out_dim, act):
+        layers = [nn.Linear(in_dim, hidden_dims[0]), act]
+        for i in range(len(hidden_dims)):
+            if i == len(hidden_dims) - 1:
+                layers.append(nn.Linear(hidden_dims[i], out_dim))
+            else:
+                layers.extend([nn.Linear(hidden_dims[i], hidden_dims[i + 1]), act])
+        super().__init__(*layers)
+
+
+class ActorMoE(nn.Module):
+    """
+    Mixture-of-Experts actor:  ⎡expert_1(x) … expert_K(x)⎤·softmax(gate(x))
+    """
+
+    def __init__(
+        self,
+        obs_dim: int,
+        act_dim: int,
+        hidden_dims,
+        num_experts: int = 4,
+        gate_hidden_dims: list[int] | None = None,
+        activation="elu",
+    ):
+        self.obs_dim = obs_dim
+        self.act_dim = act_dim
+        self.num_experts = num_experts
+        super().__init__()
+        act = resolve_nn_activation(activation)
+
+        # experts
+        self.experts = nn.ModuleList(
+            [MLP_net(obs_dim, hidden_dims, act_dim, act) for _ in range(num_experts)]
+        )
+
+        # gating network
+        gate_layers = []
+        last_dim = obs_dim
+        gate_hidden_dims = gate_hidden_dims or []
+        for h in gate_hidden_dims:
+            gate_layers += [nn.Linear(last_dim, h), act]
+            last_dim = h
+        gate_layers.append(nn.Linear(last_dim, num_experts))
+        self.gate = nn.Sequential(*gate_layers)
+        self.softmax = nn.Softmax(dim=-1)  # kept separate for ONNX clarity
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """
+        Args:
+            x: [batch, obs_dim]
+        Returns:
+            mean action: [batch, act_dim]
+        """
+        expert_out = torch.stack([e(x) for e in self.experts], dim=-1)
+        gate_logits = self.gate(x)  # [batch, K]
+        weights = self.softmax(gate_logits).unsqueeze(1)  # [batch, 1, K]
+        return (expert_out * weights).sum(-1)  # weighted sum -> [batch, A]
+
+
+class ActorCriticMoE(nn.Module):
+    """Actor-critic with Mixture-of-Experts policy."""
+
+    is_recurrent = False
+
+    def __init__(
+        self,
+        num_actor_obs: int,
+        num_critic_obs: int,
+        num_actions: int,
+        actor_hidden_dims=[256, 256, 256],
+        critic_hidden_dims=[256, 256, 256],
+        num_experts: int = 4,
+        activation: str = "elu",
+        init_noise_std: float = 1.0,
+        noise_std_type: str = "scalar",
+        **kwargs,
+    ):
+        if kwargs:
+            print(
+                (
+                    "ActorCriticMoE.__init__ ignored unexpected arguments: "
+                    + str(list(kwargs.keys()))
+                )
+            )
+        super().__init__()
+        act = resolve_nn_activation(activation)
+
+        # Actor (Mixture-of-Experts)
+        self.actor = ActorMoE(
+            obs_dim=num_actor_obs,
+            act_dim=num_actions,
+            hidden_dims=actor_hidden_dims,
+            num_experts=num_experts,
+            gate_hidden_dims=actor_hidden_dims[:-1],  # last layer is output
+            activation=activation,
+        )
+
+        # Critic
+        self.critic = MLP_net(num_critic_obs, critic_hidden_dims, 1, act)
+
+        self.noise_std_type = noise_std_type
+        if self.noise_std_type == "scalar":
+            self.std = nn.Parameter(init_noise_std * torch.ones(num_actions))
+        elif self.noise_std_type == "log":
+            self.log_std = nn.Parameter(
+                torch.log(init_noise_std * torch.ones(num_actions))
+            )
+        else:
+            raise ValueError("noise_std_type must be 'scalar' or 'log'")
+
+        # Action distribution (populated in update_distribution)
+        self.distribution = None
+        Normal.set_default_validate_args(False)
+
+        print(f"Actor (MoE) structure:\n{self.actor}")
+        print(f"Critic MLP structure:\n{self.critic}")
+
+    def reset(self, dones=None):  # noqa: D401
+        pass
+
+    def forward(self):
+        raise NotImplementedError
+
+    @property
+    def action_mean(self):
+        return self.distribution.mean
+
+    @property
+    def action_std(self):
+        return self.distribution.stddev
+
+    @property
+    def entropy(self):
+        return self.distribution.entropy().sum(dim=-1)
+
+    def update_distribution(self, observations):
+        mean = self.actor(observations)
+        if self.noise_std_type == "scalar":
+            std = self.std.expand_as(mean)
+        else:  # "log"
+            std = torch.exp(self.log_std).expand_as(mean)
+        self.distribution = Normal(mean, std)
+
+    def act(self, observations, **kwargs):
+        self.update_distribution(observations)
+        return self.distribution.sample()
+
+    def get_actions_log_prob(self, actions):
+        return self.distribution.log_prob(actions).sum(dim=-1)
+
+    def act_inference(self, observations):
+        # deterministic (mean) action
+        return self.actor(observations)
+
+    def evaluate(self, critic_observations, **kwargs):
+        return self.critic(critic_observations)
+
+    # unchanged load_state_dict so checkpoints from the old class still load
+    def load_state_dict(self, state_dict, strict=True):
+        super().load_state_dict(state_dict, strict=strict)
+        return True

--- a/amp_rsl_rl/networks/ac_moe.py
+++ b/amp_rsl_rl/networks/ac_moe.py
@@ -31,10 +31,10 @@ class ActorMoE(nn.Module):
         gate_hidden_dims: list[int] | None = None,
         activation="elu",
     ):
+        super().__init__()
         self.obs_dim = obs_dim
         self.act_dim = act_dim
         self.num_experts = num_experts
-        super().__init__()
         act = resolve_nn_activation(activation)
 
         # experts

--- a/amp_rsl_rl/runners/amp_on_policy_runner.py
+++ b/amp_rsl_rl/runners/amp_on_policy_runner.py
@@ -23,7 +23,7 @@ from rsl_rl.utils import store_code_state
 from amp_rsl_rl.utils import Normalizer
 from amp_rsl_rl.utils import AMPLoader
 from amp_rsl_rl.algorithms import AMP_PPO
-from amp_rsl_rl.networks import Discriminator
+from amp_rsl_rl.networks import Discriminator, ActorCriticMoE
 from amp_rsl_rl.utils import export_policy_as_onnx
 
 

--- a/amp_rsl_rl/utils/exporter.py
+++ b/amp_rsl_rl/utils/exporter.py
@@ -136,10 +136,11 @@ class _OnnxPolicyExporter(torch.nn.Module):
                 dynamic_axes={},
             )
         else:
-            if isinstance(self.actor, ActorMoE):
-                obs = torch.zeros(1, self.actor.obs_dim)
-            else:
-                obs = torch.zeros(1, self.actor[0].in_features)
+            obs = (
+                torch.zeros(1, self.actor.obs_dim)
+                if isinstance(self.actor, ActorMoE)
+                else torch.zeros(1, self.actor[0].in_features)
+            )
             torch.onnx.export(
                 self,
                 obs,

--- a/amp_rsl_rl/utils/exporter.py
+++ b/amp_rsl_rl/utils/exporter.py
@@ -8,6 +8,7 @@
 import copy
 import os
 import torch
+from amp_rsl_rl.networks import ActorMoE
 
 
 def export_policy_as_onnx(
@@ -135,7 +136,10 @@ class _OnnxPolicyExporter(torch.nn.Module):
                 dynamic_axes={},
             )
         else:
-            obs = torch.zeros(1, self.actor[0].in_features)
+            if isinstance(self.actor, ActorMoE):
+                obs = torch.zeros(1, self.actor.obs_dim)
+            else:
+                obs = torch.zeros(1, self.actor[0].in_features)
             torch.onnx.export(
                 self,
                 obs,


### PR DESCRIPTION
This pull request introduces the implementation of Mixture of Experts (MoE) as actor. 

---

### New Features:
* **Introduction of Mixture-of-Experts Models:**
  - Added `ActorMoE` class, which implements a Mixture-of-Experts actor model. This model combines outputs from multiple expert networks using a gating network and softmax weights. (`amp_rsl_rl/networks/ac_moe.py`, [amp_rsl_rl/networks/ac_moe.pyR1-R170](diffhunk://#diff-7e4c52406a0977cb96aca115bd039b144506958b072619647f940e5a33b24b99R1-R170))
  - Added `ActorCriticMoE` class, which extends the `ActorMoE` with a critic network for actor-critic reinforcement learning. It includes support for noise modeling and action distribution. (`amp_rsl_rl/networks/ac_moe.py`, [amp_rsl_rl/networks/ac_moe.pyR1-R170](diffhunk://#diff-7e4c52406a0977cb96aca115bd039b144506958b072619647f940e5a33b24b99R1-R170))

### Codebase Updates:
* **Module Initialization Updates:**
  - Updated `__init__.py` to include `ActorMoE` and `ActorCriticMoE` in the module's exports, ensuring they are accessible when importing the `amp_rsl_rl/networks` package. (`amp_rsl_rl/networks/__init__.py`, [amp_rsl_rl/networks/__init__.pyR10-R13](diffhunk://#diff-2a369f11c9ade1c34bb4a7432cd73d051562d66a643154d4d35f106cf7ccf311R10-R13))