### PR TITLE
Add optional acausal low-pass filtering for joint velocities in AMPLoader and angle wrapping in velocity calculation

### DIFF
--- a/amp_rsl_rl/runners/amp_on_policy_runner.py
+++ b/amp_rsl_rl/runners/amp_on_policy_runner.py
@@ -161,6 +161,7 @@ class AMPOnPolicyRunner:
             delta_t,
             self.cfg["slow_down_factor"],
             amp_joint_names,
+            6.0,
         )
 
         # self.env.unwrapped.scene["robot"].joint_names)


### PR DESCRIPTION
This pull request enhances the `AMPLoader` class in `amp_rsl_rl/utils/motion_loader.py` to support improved velocity computation and optional acausal low-pass filtering. The most significant changes introduce robust handling of angular velocities and an option to filter velocities to reduce noise, which benefits downstream motion modeling and simulation stability.

### Velocity computation improvements
* The `_compute_raw_derivative` method now correctly handles wrapped angles for angular data, preventing artifacts from jumps across ±π. This is used for joint velocity calculation, ensuring accurate representation of rotational velocities. [[1]](diffhunk://#diff-c8064b1baa437252509b1b8995c0fce59c5295e107e7a479381c351ae25b3620L305-R365) [[2]](diffhunk://#diff-c8064b1baa437252509b1b8995c0fce59c5295e107e7a479381c351ae25b3620R406-R408)
* The joint velocity calculation in `load_data` is updated to use angular difference handling, and base velocities explicitly specify whether angular handling is needed. [[1]](diffhunk://#diff-c8064b1baa437252509b1b8995c0fce59c5295e107e7a479381c351ae25b3620R406-R408) [[2]](diffhunk://#diff-c8064b1baa437252509b1b8995c0fce59c5295e107e7a479381c351ae25b3620L361-R419)

### Optional acausal low-pass filtering
* Added a new `vel_filter_cutoff_hz` parameter to the `AMPLoader` constructor, allowing users to specify a cutoff frequency for filtering velocities. [[1]](diffhunk://#diff-c8064b1baa437252509b1b8995c0fce59c5295e107e7a479381c351ae25b3620R189-R190) [[2]](diffhunk://#diff-c8064b1baa437252509b1b8995c0fce59c5295e107e7a479381c351ae25b3620R202-R205)
* Implemented the `_lowpass_acausal` method using a 2nd-order Butterworth filter and zero-phase filtering (`filtfilt`), and applied it to all velocity signals in `load_data` if the cutoff is set. This helps suppress high-frequency noise in both joint and base velocities. [[1]](diffhunk://#diff-c8064b1baa437252509b1b8995c0fce59c5295e107e7a479381c351ae25b3620L305-R365) [[2]](diffhunk://#diff-c8064b1baa437252509b1b8995c0fce59c5295e107e7a479381c351ae25b3620R438-R456)

### Dependency update
* Added imports for `butter` and `filtfilt` from `scipy.signal` to support the new filtering functionality.