### PR TITLE
Enhance Discriminator with minibatch standard deviation

### DIFF
--- a/amp_rsl_rl/networks/discriminator.py
+++ b/amp_rsl_rl/networks/discriminator.py
@@ -21,6 +21,9 @@ class Discriminator(nn.Module):
         hidden_layer_sizes (list): List of hidden layer sizes.
         reward_scale (float): Scale factor for the computed reward.
         device (str): Device to run the model on ('cpu' or 'cuda').
+        loss_type (str): Type of loss function to use ('BCEWithLogits' or 'Wasserstein').
+        eta_wgan (float): Scaling factor for the Wasserstein loss (if used).
+        use_minibatch_std (bool): Whether to use minibatch standard deviation in the network
     """
 
     def __init__(


### PR DESCRIPTION
This PR introduces the use of minibatch std regularizer. This technique improves mode collapse handling by rewarding minibatches that contain "various" data, which, in this particular case, means having data that expresses different motions. 
This helps out when the generated data are similar to the ones in the dataset but are all the same (aka mode collapse). 
 
**Discriminator architecture and feature enhancements:**

* Added a `use_minibatch_std` option to the `Discriminator`, which, when enabled, appends the minibatch standard deviation as an extra feature to the last hidden layer before the final linear output. This can help stabilize GAN training by providing batch-level statistics. [[1]](diffhunk://#diff-c269da6f7ef5d002e1b1683cd2edd9f582b14b6ef14b67a5c93d3bda9a6a712dR35) [[2]](diffhunk://#diff-c269da6f7ef5d002e1b1683cd2edd9f582b14b6ef14b67a5c93d3bda9a6a712dL50-R57) [[3]](diffhunk://#diff-c269da6f7ef5d002e1b1683cd2edd9f582b14b6ef14b67a5c93d3bda9a6a712dL73-R90)

**Reward calculation improvements:**

* Changed the reward computation for non-Wasserstein loss to use `F.softplus` for improved numerical stability and clarity, replacing the previous formulation involving `sigmoid` and `log`.

**Gradient penalty and regularization logic:**

* Updated the gradient penalty calculation to properly handle both Wasserstein and BCEWithLogits loss types, including correct handling of the minibatch-std feature and regularization constants. The R1 regularizer for BCEWithLogits now detaches minibatch statistics to ensure gradients are only with respect to the real samples. [[1]](diffhunk://#diff-c269da6f7ef5d002e1b1683cd2edd9f582b14b6ef14b67a5c93d3bda9a6a712dR204-R212) [[2]](diffhunk://#diff-c269da6f7ef5d002e1b1683cd2edd9f582b14b6ef14b67a5c93d3bda9a6a712dL219-R246)

**Internal code improvements:**

* Imported `torch.nn.functional as F` for improved functional API usage.