### PR TITLE
Add compatibility with rsl_rl v3, v4, and v5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: 🧪 CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        rsl-rl-version: ["3.1.3", "3.3.0", "4.0.1", "5.2.0"]
+        python-version: ["3.10"]
+
+    name: rsl-rl-lib ${{ matrix.rsl-rl-version }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: 🐍 Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: 📦 Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install "rsl-rl-lib==${{ matrix.rsl-rl-version }}"
+          pip install -e ".[examples,mlflow]"
+          pip install pytest
+
+      - name: 🧪 Run tests
+        run: python -m pytest tests/ -v

--- a/amp_rsl_rl/algorithms/amp_ppo.py
+++ b/amp_rsl_rl/algorithms/amp_ppo.py
@@ -13,13 +13,12 @@ import torch.nn as nn
 import torch.optim as optim
 from tensordict import TensorDict
 
-# External modules providing the actor-critic model, storage utilities, and AMP components.
-from rsl_rl.modules import ActorCritic
 from rsl_rl.storage import RolloutStorage
 
 from amp_rsl_rl.storage import ReplayBuffer
 from amp_rsl_rl.networks import Discriminator
 from amp_rsl_rl.utils import AMPLoader
+from amp_rsl_rl.utils._compat import RSL_RL_V4_PLUS, RSL_RL_V5_PLUS
 
 
 class AMP_PPO:
@@ -32,8 +31,6 @@ class AMP_PPO:
 
     Parameters
     ----------
-    actor_critic : ActorCritic
-        Policy network providing ``act``/``evaluate``/``update_normalization`` APIs.
     discriminator : Discriminator
         AMP discriminator distinguishing expert vs policy motion pairs.
     amp_data : AMPLoader
@@ -70,13 +67,13 @@ class AMP_PPO:
         Torch device used by the module.
     """
 
-    actor_critic: ActorCritic
-
     def __init__(
         self,
-        actor_critic: ActorCritic,
         discriminator: Discriminator,
         amp_data: AMPLoader,
+        actor_critic=None,
+        actor=None,
+        critic=None,
         num_learning_epochs: int = 1,
         num_mini_batches: int = 1,
         clip_param: float = 0.2,
@@ -99,6 +96,24 @@ class AMP_PPO:
         self.schedule: str = schedule
         self.learning_rate: float = learning_rate
 
+        if RSL_RL_V4_PLUS:
+            if actor is None or critic is None:
+                raise ValueError(
+                    "rsl-rl-lib >= 4 detected: 'actor' and 'critic' must both be provided to AMP_PPO."
+                )
+            self.actor = actor.to(self.device)
+            self.critic = critic.to(self.device)
+            self.actor_critic = None
+        else:
+            if actor_critic is None:
+                raise ValueError(
+                    "rsl-rl-lib < 4 detected: 'actor_critic' must be provided to AMP_PPO."
+                )
+            # Set up the actor-critic (policy) and move it to the device.
+            self.actor_critic = actor_critic.to(self.device)
+            self.actor = self.actor_critic
+            self.critic = None
+
         # Set up the discriminator and move it to the appropriate device.
         self.discriminator: Discriminator = discriminator.to(self.device)
         self.amp_transition: RolloutStorage.Transition = RolloutStorage.Transition()
@@ -109,31 +124,44 @@ class AMP_PPO:
             obs_dim=obs_dim, buffer_size=amp_replay_buffer_size, device=device
         )
         self.amp_data: AMPLoader = amp_data
-
-        # Set up the actor-critic (policy) and move it to the device.
-        self.actor_critic = actor_critic
-        self.actor_critic.to(self.device)
         self.storage: Optional[RolloutStorage] = (
             None  # Will be initialized later once environment parameters are known
         )
 
         # Create optimizer for both the actor-critic and the discriminator.
         # Note: Weight decay is set differently for discriminator trunk and head.
-        params = [
-            {"params": self.actor_critic.parameters(), "name": "actor_critic"},
-            {
-                "params": self.discriminator.trunk.parameters(),
-                "weight_decay": 10e-4,
-                "name": "amp_trunk",
-            },
-            {
-                "params": self.discriminator.linear.parameters(),
-                "weight_decay": 10e-2,
-                "name": "amp_head",
-            },
-        ]
+        if RSL_RL_V4_PLUS:
+            params = [
+                {"params": self.actor.parameters(), "name": "actor"},
+                {"params": self.critic.parameters(), "name": "critic"},
+                {
+                    "params": self.discriminator.trunk.parameters(),
+                    "weight_decay": 10e-4,
+                    "name": "amp_trunk",
+                },
+                {
+                    "params": self.discriminator.linear.parameters(),
+                    "weight_decay": 10e-2,
+                    "name": "amp_head",
+                },
+            ]
+        else:
+            params = [
+                {"params": self.actor_critic.parameters(), "name": "actor_critic"},
+                {
+                    "params": self.discriminator.trunk.parameters(),
+                    "weight_decay": 10e-4,
+                    "name": "amp_trunk",
+                },
+                {
+                    "params": self.discriminator.linear.parameters(),
+                    "weight_decay": 10e-2,
+                    "name": "amp_head",
+                },
+            ]
         self.optimizer: optim.Adam = optim.Adam(params, lr=learning_rate)
         self.transition: RolloutStorage.Transition = RolloutStorage.Transition()
+
         # PPO-specific parameters
         self.clip_param: float = clip_param
         self.num_learning_epochs: int = num_learning_epochs
@@ -179,13 +207,21 @@ class AMP_PPO:
         """
         Sets the actor-critic model to evaluation mode.
         """
-        self.actor_critic.eval()
+        if RSL_RL_V4_PLUS:
+            self.actor.eval()
+            self.critic.eval()
+        else:
+            self.actor_critic.eval()
 
     def train_mode(self) -> None:
         """
         Sets the actor-critic model to training mode.
         """
-        self.actor_critic.train()
+        if RSL_RL_V4_PLUS:
+            self.actor.train()
+            self.critic.train()
+        else:
+            self.actor_critic.train()
 
     def act(self, obs: TensorDict) -> torch.Tensor:
         """Select an action and value estimate for the current observation.
@@ -200,16 +236,33 @@ class AMP_PPO:
         torch.Tensor
             Detached action tensor sampled from the actor-critic policy.
         """
-        if self.actor_critic.is_recurrent:
-            self.transition.hidden_states = self.actor_critic.get_hidden_states()
+        if RSL_RL_V4_PLUS:
+            if self.actor.is_recurrent:
+                self.transition.hidden_states = self.actor.get_hidden_state()
+            self.transition.actions = self.actor(obs, stochastic_output=True).detach()
+            self.transition.values = self.critic(obs).detach()
+            self.transition.actions_log_prob = self.actor.get_output_log_prob(
+                self.transition.actions
+            ).detach()
+            if RSL_RL_V5_PLUS:
+                self.transition.distribution_params = [
+                    self.actor.output_mean.detach(),
+                    self.actor.output_std.detach(),
+                ]
+            else:
+                self.transition.action_mean = self.actor.output_mean.detach()
+                self.transition.action_sigma = self.actor.output_std.detach()
+        else:
+            if self.actor_critic.is_recurrent:
+                self.transition.hidden_states = self.actor_critic.get_hidden_states()
+            self.transition.actions = self.actor_critic.act(obs).detach()
+            self.transition.values = self.actor_critic.evaluate(obs).detach()
+            self.transition.actions_log_prob = self.actor_critic.get_actions_log_prob(
+                self.transition.actions
+            ).detach()
+            self.transition.action_mean = self.actor_critic.action_mean.detach()
+            self.transition.action_sigma = self.actor_critic.action_std.detach()
 
-        self.transition.actions = self.actor_critic.act(obs).detach()
-        self.transition.values = self.actor_critic.evaluate(obs).detach()
-        self.transition.actions_log_prob = self.actor_critic.get_actions_log_prob(
-            self.transition.actions
-        ).detach()
-        self.transition.action_mean = self.actor_critic.action_mean.detach()
-        self.transition.action_sigma = self.actor_critic.action_std.detach()
         self.transition.observations = obs
         return self.transition.actions
 
@@ -243,7 +296,11 @@ class AMP_PPO:
         extras : dict[str, Any]
             Additional metadata from the environment (e.g. ``time_outs``).
         """
-        self.actor_critic.update_normalization(obs)
+        if RSL_RL_V4_PLUS:
+            self.actor.update_normalization(obs)
+            self.critic.update_normalization(obs)
+        else:
+            self.actor_critic.update_normalization(obs)
 
         self.transition.rewards = rewards.clone()
         self.transition.dones = dones
@@ -255,9 +312,15 @@ class AMP_PPO:
                 1,
             )
 
-        self.storage.add_transitions(self.transition)
-        self.transition.clear()
-        self.actor_critic.reset(dones)
+        if RSL_RL_V4_PLUS:
+            self.storage.add_transition(self.transition)
+            self.transition.clear()
+            self.actor.reset(dones)
+            self.critic.reset(dones)
+        else:
+            self.storage.add_transitions(self.transition)
+            self.transition.clear()
+            self.actor_critic.reset(dones)
 
     def process_amp_step(self, amp_obs: torch.Tensor) -> None:
         """Insert a policy-generated AMP transition into the replay buffer.
@@ -278,9 +341,29 @@ class AMP_PPO:
         obs : TensorDict
             Last observation gathered after rollout completion.
         """
-
-        last_values = self.actor_critic.evaluate(obs).detach()
-        self.storage.compute_returns(last_values, self.gamma, self.lam)
+        if RSL_RL_V4_PLUS:
+            last_values = self.critic(obs).detach()
+            st = self.storage
+            advantage = 0
+            for step in reversed(range(st.num_transitions_per_env)):
+                next_values = (
+                    last_values if step == st.num_transitions_per_env - 1 else st.values[step + 1]
+                )
+                next_is_not_terminal = 1.0 - st.dones[step].float()
+                delta = (
+                    st.rewards[step]
+                    + next_is_not_terminal * self.gamma * next_values
+                    - st.values[step]
+                )
+                advantage = delta + next_is_not_terminal * self.gamma * self.lam * advantage
+                st.returns[step] = advantage + st.values[step]
+            st.advantages = st.returns - st.values
+            st.advantages = (st.advantages - st.advantages.mean()) / (
+                st.advantages.std() + 1e-8
+            )
+        else:
+            last_values = self.actor_critic.evaluate(obs).detach()
+            self.storage.compute_returns(last_values, self.gamma, self.lam)
 
     def update(
         self,
@@ -312,7 +395,9 @@ class AMP_PPO:
         mean_kl_divergence: float = 0.0
 
         # Create data generators for mini-batch sampling.
-        if self.actor_critic.is_recurrent:
+        _is_recurrent = self.actor.is_recurrent if RSL_RL_V4_PLUS else self.actor_critic.is_recurrent
+
+        if _is_recurrent:
             generator = self.storage.recurrent_mini_batch_generator(
                 self.num_mini_batches, self.num_learning_epochs
             )
@@ -324,12 +409,13 @@ class AMP_PPO:
         # Generator for policy-generated AMP transitions.
         amp_policy_generator = self.amp_storage.feed_forward_generator(
             num_mini_batch=self.num_learning_epochs * self.num_mini_batches,
-            mini_batch_size=self.storage.num_envs
-            * self.storage.num_transitions_per_env
-            // self.num_mini_batches,
+            mini_batch_size=(
+                self.storage.num_envs
+                * self.storage.num_transitions_per_env
+                // self.num_mini_batches
+            ),
             allow_replacement=True,
         )
-
         # Generator for expert AMP data.
         amp_expert_generator = self.amp_data.feed_forward_generator(
             self.num_learning_epochs * self.num_mini_batches,
@@ -343,36 +429,82 @@ class AMP_PPO:
             generator, amp_policy_generator, amp_expert_generator
         ):
             # Unpack the mini-batch sample from the environment.
-            (
-                obs_batch,
-                actions_batch,
-                target_values_batch,
-                advantages_batch,
-                returns_batch,
-                old_actions_log_prob_batch,
-                old_mu_batch,
-                old_sigma_batch,
-                hidden_states_batch,
-                masks_batch,
-            ) = sample
+            if hasattr(sample, "observations"):
+                obs_batch = sample.observations
+                actions_batch = sample.actions
+                target_values_batch = sample.values
+                advantages_batch = sample.advantages
+                returns_batch = sample.returns
+                old_actions_log_prob_batch = sample.old_actions_log_prob
+                old_mu_batch = sample.old_distribution_params[0]
+                old_sigma_batch = sample.old_distribution_params[1]
+                hidden_states_batch = sample.hidden_states
+                masks_batch = sample.masks
+            elif isinstance(sample, tuple) and len(sample) == 9:
+                (
+                    obs_batch,
+                    actions_batch,
+                    target_values_batch,
+                    advantages_batch,
+                    returns_batch,
+                    old_actions_log_prob_batch,
+                    old_distribution_params_batch,
+                    hidden_states_batch,
+                    masks_batch,
+                ) = sample
+                old_mu_batch = old_distribution_params_batch[0]
+                old_sigma_batch = old_distribution_params_batch[1]
+            else:
+                (
+                    obs_batch,
+                    actions_batch,
+                    target_values_batch,
+                    advantages_batch,
+                    returns_batch,
+                    old_actions_log_prob_batch,
+                    old_mu_batch,
+                    old_sigma_batch,
+                    hidden_states_batch,
+                    masks_batch,
+                ) = sample
 
             hidden_state_actor, hidden_state_critic = (None, None)
             if hidden_states_batch is not None:
                 hidden_state_actor, hidden_state_critic = hidden_states_batch
 
             # Forward pass through the actor to get current policy outputs.
-            self.actor_critic.act(
-                obs_batch, masks=masks_batch, hidden_states=hidden_state_actor
-            )
-            actions_log_prob_batch = self.actor_critic.get_actions_log_prob(
-                actions_batch
-            )
-            value_batch = self.actor_critic.evaluate(
-                obs_batch, masks=masks_batch, hidden_states=hidden_state_critic
-            )
-            mu_batch = self.actor_critic.action_mean
-            sigma_batch = self.actor_critic.action_std
-            entropy_batch = self.actor_critic.entropy
+            if RSL_RL_V4_PLUS:
+                _ = self.actor(
+                    obs_batch,
+                    masks=masks_batch,
+                    hidden_state=hidden_state_actor,
+                    stochastic_output=True,
+                )
+                actions_log_prob_batch = self.actor.get_output_log_prob(actions_batch)
+                value_batch = self.critic(
+                    obs_batch, masks=masks_batch, hidden_state=hidden_state_critic
+                )
+                if hasattr(self.actor, "get_distribution_params"):
+                    dist_params = self.actor.get_distribution_params()
+                    mu_batch = dist_params[0]
+                    sigma_batch = dist_params[1]
+                    entropy_batch = self.actor.get_entropy()
+                else:
+                    mu_batch = self.actor.output_mean
+                    sigma_batch = self.actor.output_std
+                    entropy_batch = self.actor.output_entropy
+            else:
+                # v3
+                self.actor_critic.act(
+                    obs_batch, masks=masks_batch, hidden_states=hidden_state_actor
+                )
+                actions_log_prob_batch = self.actor_critic.get_actions_log_prob(actions_batch)
+                value_batch = self.actor_critic.evaluate(
+                    obs_batch, masks=masks_batch, hidden_states=hidden_state_critic
+                )
+                mu_batch = self.actor_critic.action_mean
+                sigma_batch = self.actor_critic.action_std
+                entropy_batch = self.actor_critic.entropy
 
             # Adaptive learning rate adjustment based on KL divergence if schedule is "adaptive".
             if self.desired_kl is not None and self.schedule == "adaptive":
@@ -484,7 +616,11 @@ class AMP_PPO:
             # Backpropagation and optimizer step.
             self.optimizer.zero_grad()
             loss.backward()
-            nn.utils.clip_grad_norm_(self.actor_critic.parameters(), self.max_grad_norm)
+            if RSL_RL_V4_PLUS:
+                nn.utils.clip_grad_norm_(self.actor.parameters(), self.max_grad_norm)
+                nn.utils.clip_grad_norm_(self.critic.parameters(), self.max_grad_norm)
+            else:
+                nn.utils.clip_grad_norm_(self.actor_critic.parameters(), self.max_grad_norm)
             self.optimizer.step()
 
             # Update the normalizer with RAW (unnormalized) observations under no_grad

--- a/amp_rsl_rl/algorithms/amp_ppo.py
+++ b/amp_rsl_rl/algorithms/amp_ppo.py
@@ -342,6 +342,8 @@ class AMP_PPO:
             Last observation gathered after rollout completion.
         """
         if RSL_RL_V4_PLUS:
+            # v4+ removed compute_returns from RolloutStorage
+            # (see https://github.com/leggedrobotics/rsl_rl/pull/137)
             last_values = self.critic(obs).detach()
             st = self.storage
             advantage = 0

--- a/amp_rsl_rl/networks/ac_moe.py
+++ b/amp_rsl_rl/networks/ac_moe.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import torch
 import torch.nn as nn
 from torch.distributions import Normal
-from rsl_rl.networks import EmpiricalNormalization
+from amp_rsl_rl.utils._compat import EmpiricalNormalization
 from rsl_rl.utils import resolve_nn_activation
 
 

--- a/amp_rsl_rl/networks/discriminator.py
+++ b/amp_rsl_rl/networks/discriminator.py
@@ -7,12 +7,7 @@ import torch
 import torch.nn as nn
 from torch import autograd
 from torch.nn import functional as F
-from amp_rsl_rl.utils._compat import RSL_RL_V4_PLUS, RSL_RL_V5_PLUS
-
-if RSL_RL_V4_PLUS:
-    from rsl_rl.modules.normalization import EmpiricalNormalization
-else:
-    from rsl_rl.networks import EmpiricalNormalization
+from amp_rsl_rl.utils._compat import EmpiricalNormalization
 
 
 class Discriminator(nn.Module):

--- a/amp_rsl_rl/networks/discriminator.py
+++ b/amp_rsl_rl/networks/discriminator.py
@@ -7,8 +7,12 @@ import torch
 import torch.nn as nn
 from torch import autograd
 from torch.nn import functional as F
+from amp_rsl_rl.utils._compat import RSL_RL_V4_PLUS, RSL_RL_V5_PLUS
 
-from rsl_rl.networks import EmpiricalNormalization
+if RSL_RL_V4_PLUS:
+    from rsl_rl.modules.normalization import EmpiricalNormalization
+else:
+    from rsl_rl.networks import EmpiricalNormalization
 
 
 class Discriminator(nn.Module):

--- a/amp_rsl_rl/runners/amp_on_policy_runner.py
+++ b/amp_rsl_rl/runners/amp_on_policy_runner.py
@@ -18,22 +18,34 @@ from torch.utils.tensorboard import SummaryWriter as TensorboardSummaryWriter
 
 import rsl_rl
 from rsl_rl.env import VecEnv
-from rsl_rl.modules import ActorCritic, ActorCriticRecurrent
-from rsl_rl.utils import resolve_obs_groups, store_code_state
 
 import amp_rsl_rl
 from amp_rsl_rl.utils import AMPLoader
 from amp_rsl_rl.algorithms import AMP_PPO
 from amp_rsl_rl.networks import Discriminator, ActorCriticMoE
 from amp_rsl_rl.utils import export_policy_as_onnx
+from amp_rsl_rl.utils._compat import RSL_RL_V4_PLUS, store_code_state, resolve_obs_groups
+
+if RSL_RL_V4_PLUS:
+    from rsl_rl.models import MLPModel
+    _v4_builtin_classes = {"MLPModel": MLPModel}
+else:
+    from rsl_rl.modules import ActorCritic, ActorCriticRecurrent
+    _v4_builtin_classes = {}
 
 # Built-in classes available for short-name resolution
 _BUILTIN_CLASSES = {
-    "ActorCritic": ActorCritic,
-    "ActorCriticRecurrent": ActorCriticRecurrent,
     "ActorCriticMoE": ActorCriticMoE,
     "AMP_PPO": AMP_PPO,
+    **_v4_builtin_classes,
 }
+if not RSL_RL_V4_PLUS:
+    _BUILTIN_CLASSES.update(
+        {
+            "ActorCritic": ActorCritic,
+            "ActorCriticRecurrent": ActorCriticRecurrent,
+        }
+    )
 
 
 def resolve_class(class_name: str) -> type:
@@ -175,7 +187,6 @@ class AMPOnPolicyRunner:
     def __init__(self, env: VecEnv, train_cfg, log_dir=None, device="cpu"):
         self.cfg = train_cfg
         self.alg_cfg = train_cfg["algorithm"]
-        self.policy_cfg = train_cfg["policy"]
         self.discriminator_cfg = train_cfg["discriminator"]
         self.dataset_cfg = train_cfg["dataset"]
         self.device = device
@@ -190,34 +201,68 @@ class AMPOnPolicyRunner:
             observations, self.cfg.get("obs_groups"), default_sets
         )
 
-        actor_critic_class = resolve_class(self.policy_cfg.pop("class_name"))
-        actor_critic: ActorCritic | ActorCriticRecurrent | ActorCriticMoE = (
-            actor_critic_class(
+        if RSL_RL_V4_PLUS:
+            self.actor_cfg = train_cfg["actor"]
+            self.critic_cfg = train_cfg["critic"]
+            self.policy_cfg = {}
+
+            self.actor_cfg.pop("cnn_cfg", None)
+            self.critic_cfg.pop("cnn_cfg", None)
+            actor_class = resolve_class(self.actor_cfg.pop("class_name", "MLPModel"))
+            critic_class = resolve_class(self.critic_cfg.pop("class_name", "MLPModel"))
+
+            actor = actor_class(
+                observations,
+                self.cfg["obs_groups"],
+                "actor",
+                self.env.num_actions,
+                **self.actor_cfg,
+            ).to(self.device)
+            critic = critic_class(
+                observations,
+                self.cfg["obs_groups"],
+                "critic",
+                1,
+                **self.critic_cfg,
+            ).to(self.device)
+        else:
+            self.policy_cfg = train_cfg["policy"]
+            self.actor_cfg = {}
+            self.critic_cfg = {}
+
+            actor_critic_class = resolve_class(self.policy_cfg.pop("class_name"))
+            # NOTE: to use this we need to configure the observations in the env coherently with amp observation. Tested with Manager Based envs in Isaaclab
+            actor_critic = actor_critic_class(
                 observations,
                 self.cfg["obs_groups"],
                 self.env.num_actions,
                 **self.policy_cfg,
             ).to(self.device)
-        )
-        # NOTE: to use this we need to configure the observations in the env coherently with amp observation. Tested with Manager Based envs in Isaaclab
-        amp_joint_names = self.env.cfg.observations.amp.joint_pos.params[
-            "asset_cfg"
-        ].joint_names
+
+        amp_joint_names = self.dataset_cfg.get("amp_joint_names", None)
+        if amp_joint_names is None and not RSL_RL_V4_PLUS:
+            try:
+                amp_joint_names = self.env.cfg.observations.amp.joint_pos.params[
+                    "asset_cfg"
+                ].joint_names
+            except AttributeError:
+                amp_joint_names = None
+
+        simulation_dt = self._resolve_simulation_dt()
 
         # Initialize all the ingredients required for AMP (discriminator, dataset loader)
-        num_amp_obs = observations["amp"].shape[1]
+        num_amp_obs = self._flatten_amp_obs(observations["amp"]).shape[1]
         amp_data = AMPLoader(
             device=self.device,
             dataset_path_root=self.dataset_cfg["amp_data_path"],
             datasets=self.dataset_cfg["datasets"],
-            simulation_dt=self.env.cfg.sim.dt * self.env.cfg.decimation,
+            simulation_dt=simulation_dt,
             slow_down_factor=self.dataset_cfg["slow_down_factor"],
             expected_joint_names=amp_joint_names,
         )
 
         self.discriminator = Discriminator(
-            input_dim=num_amp_obs
-            * 2,  # the discriminator takes in the concatenation of the current and next observation
+            input_dim=num_amp_obs * 2,  # the discriminator takes in the concatenation of the current and next observation
             hidden_layer_sizes=self.discriminator_cfg["hidden_dims"],
             reward_scale=self.discriminator_cfg["reward_scale"],
             device=self.device,
@@ -236,15 +281,27 @@ class AMPOnPolicyRunner:
             if key not in AMP_PPO.__init__.__code__.co_varnames:
                 self.alg_cfg.pop(key)
 
-        self.alg: AMP_PPO = alg_class(
-            actor_critic=actor_critic,
-            discriminator=self.discriminator,
-            amp_data=amp_data,
-            device=self.device,
-            **self.alg_cfg,
-        )
+        if RSL_RL_V4_PLUS:
+            self.alg: AMP_PPO = alg_class(
+                actor=actor,
+                critic=critic,
+                discriminator=self.discriminator,
+                amp_data=amp_data,
+                device=self.device,
+                **self.alg_cfg,
+            )
+        else:
+            self.alg: AMP_PPO = alg_class(
+                actor_critic=actor_critic,
+                discriminator=self.discriminator,
+                amp_data=amp_data,
+                device=self.device,
+                **self.alg_cfg,
+            )
+
         self.num_steps_per_env = self.cfg["num_steps_per_env"]
         self.save_interval = self.cfg["save_interval"]
+
         # init storage and model
         obs_template = observations.clone().detach().to(self.device)
         self.alg.init_storage(
@@ -262,6 +319,39 @@ class AMPOnPolicyRunner:
         self.tot_time = 0
         self.current_learning_iteration = 0
         self.git_status_repos = [rsl_rl.__file__, amp_rsl_rl.__file__]
+
+    @staticmethod
+    def _flatten_amp_obs(amp_obs) -> torch.Tensor:
+        if isinstance(amp_obs, torch.Tensor):
+            return amp_obs
+        if isinstance(amp_obs, dict):
+            if "joint_pos" in amp_obs and "joint_vel" in amp_obs:
+                return torch.cat([amp_obs["joint_pos"], amp_obs["joint_vel"]], dim=-1)
+            keys = sorted(amp_obs.keys())
+            return torch.cat([amp_obs[k] for k in keys], dim=-1)
+        if hasattr(amp_obs, "keys"):
+            if "joint_pos" in amp_obs and "joint_vel" in amp_obs:
+                return torch.cat([amp_obs["joint_pos"], amp_obs["joint_vel"]], dim=-1)
+            keys = sorted(amp_obs.keys())
+            return torch.cat([amp_obs[k] for k in keys], dim=-1)
+        raise TypeError(f"Unsupported AMP observation type: {type(amp_obs)}")
+
+    def _resolve_simulation_dt(self) -> float:
+        sim_cfg = getattr(self.env.cfg, "sim", None)
+        decimation = float(getattr(self.env.cfg, "decimation", 1))
+        base_dt = None
+        if sim_cfg is not None:
+            base_dt = getattr(sim_cfg, "dt", None)
+            if base_dt is None:
+                mujoco_cfg = getattr(sim_cfg, "mujoco", None)
+                if mujoco_cfg is not None:
+                    base_dt = getattr(mujoco_cfg, "timestep", None)
+        if base_dt is None:
+            raise AttributeError(
+                "Unable to resolve simulation dt from env config. Expected either "
+                "`env.cfg.sim.dt` or `env.cfg.sim.mujoco.timestep`."
+            )
+        return float(base_dt) * decimation
 
     def learn(self, num_learning_iterations: int, init_at_random_ep_len: bool = False):
         # initialize writer
@@ -320,9 +410,10 @@ class AMPOnPolicyRunner:
                 self.writer = WandbSummaryWriter(
                     log_dir=self.log_dir, flush_secs=10, cfg=self.cfg
                 )
-                update_run_name_with_sequence(
-                    prefix=self.cfg["wandb_kwargs"]["project"]
-                )
+                _wandb_project = self.cfg.get("wandb_project") or self.cfg.get(
+                    "wandb_kwargs", {}
+                ).get("project", "")
+                update_run_name_with_sequence(prefix=_wandb_project)
 
                 self.writer.log_config(
                     self.env.cfg, self.cfg, self.alg_cfg, self.policy_cfg
@@ -348,7 +439,7 @@ class AMPOnPolicyRunner:
                 self.env.episode_length_buf, high=int(self.env.max_episode_length)
             )
         obs = self.env.get_observations().to(self.device)
-        amp_obs = obs["amp"].clone()
+        amp_obs = self._flatten_amp_obs(obs["amp"]).clone()
         self.train_mode()  # switch to train mode (for dropout for example)
 
         ep_infos = []
@@ -381,7 +472,7 @@ class AMPOnPolicyRunner:
                     rewards = rewards.to(self.device)
                     dones = dones.to(self.device)
 
-                    next_amp_obs = obs["amp"].clone()
+                    next_amp_obs = self._flatten_amp_obs(obs["amp"]).clone()
                     style_rewards = self.discriminator.predict_reward(
                         amp_obs, next_amp_obs
                     )
@@ -484,10 +575,15 @@ class AMPOnPolicyRunner:
                 else:
                     self.writer.add_scalar("Episode/" + key, value, locs["it"])
                     ep_string += f"""{f'Mean episode {key}:':>{pad}} {value:.4f}\n"""
-        if getattr(self.alg.actor_critic, "noise_std_type", "scalar") == "log":
-            mean_std_value = torch.exp(self.alg.actor_critic.log_std).mean()
+        _policy_ref = self.alg.actor if RSL_RL_V4_PLUS else self.alg.actor_critic
+        if hasattr(_policy_ref, "distribution") and hasattr(
+            _policy_ref.distribution, "std_param"
+        ):
+            mean_std_value = _policy_ref.distribution.std_param.mean()
+        elif getattr(_policy_ref, "noise_std_type", "scalar") == "log":
+            mean_std_value = torch.exp(_policy_ref.log_std).mean()
         else:
-            mean_std_value = self.alg.actor_critic.std.mean()
+            mean_std_value = _policy_ref.std.mean()
         fps = int(
             self.num_steps_per_env
             * self.env.num_envs
@@ -623,13 +719,23 @@ class AMPOnPolicyRunner:
         self._export_policy_fn = fn
 
     def save(self, path, infos=None, save_onnx=False):
-        saved_dict = {
-            "model_state_dict": self.alg.actor_critic.state_dict(),
-            "optimizer_state_dict": self.alg.optimizer.state_dict(),
-            "discriminator_state_dict": self.alg.discriminator.state_dict(),
-            "iter": self.current_learning_iteration,
-            "infos": infos,
-        }
+        if RSL_RL_V4_PLUS:
+            saved_dict = {
+                "actor_state_dict": self.alg.actor.state_dict(),
+                "critic_state_dict": self.alg.critic.state_dict(),
+                "optimizer_state_dict": self.alg.optimizer.state_dict(),
+                "discriminator_state_dict": self.alg.discriminator.state_dict(),
+                "iter": self.current_learning_iteration,
+                "infos": infos,
+            }
+        else:
+            saved_dict = {
+                "model_state_dict": self.alg.actor_critic.state_dict(),
+                "optimizer_state_dict": self.alg.optimizer.state_dict(),
+                "discriminator_state_dict": self.alg.discriminator.state_dict(),
+                "iter": self.current_learning_iteration,
+                "infos": infos,
+            }
         torch.save(saved_dict, path)
 
         # Upload model to external logging service
@@ -640,16 +746,25 @@ class AMPOnPolicyRunner:
             # Save the model in ONNX format
             # extract the folder path
             onnx_folder = os.path.dirname(path)
-
             # extract the iteration number from the path. The path is expected to be in the format
             # model_{iteration}.pt
             iteration = int(os.path.basename(path).split("_")[1].split(".")[0])
             onnx_model_name = f"policy_{iteration}.onnx"
 
+            if RSL_RL_V4_PLUS:
+                _module = self.alg.actor
+            else:
+                _module = self.alg.actor_critic
+            _normalizer = getattr(
+                _module,
+                "actor_obs_normalizer",
+                getattr(_module, "obs_normalizer", None),
+            )
+
             _export_fn = self._export_policy_fn or export_policy_as_onnx
             _export_fn(
-                self.alg.actor_critic,
-                normalizer=self.alg.actor_critic.actor_obs_normalizer,
+                _module,
+                normalizer=_normalizer,
                 path=onnx_folder,
                 filename=onnx_model_name,
             )
@@ -660,39 +775,79 @@ class AMPOnPolicyRunner:
                     self.current_learning_iteration,
                 )
 
-    def load(self, path, load_optimizer=True, weights_only=False):
+    def load(self, path, load_optimizer=True, weights_only=False, load_cfg=None, strict=True, map_location=None, **kwargs):
+        if load_cfg is None:
+            load_cfg = {}
+        do_load_optimizer = load_cfg.get("optimizer", load_optimizer)
+
         loaded_dict = torch.load(
-            path, map_location=self.device, weights_only=weights_only
+            path,
+            map_location=(map_location if map_location is not None else self.device),
+            weights_only=weights_only,
         )
-        self.alg.actor_critic.load_state_dict(loaded_dict["model_state_dict"])
-        discriminator_state = loaded_dict["discriminator_state_dict"]
-        self.alg.discriminator.load_state_dict(discriminator_state, strict=False)
+
+        if RSL_RL_V4_PLUS:
+            do_load_actor = load_cfg.get("actor", True)
+            do_load_critic = load_cfg.get("critic", True)
+            do_load_discriminator = load_cfg.get("discriminator", True)
+
+            if do_load_actor and "actor_state_dict" in loaded_dict:
+                actor_state = loaded_dict["actor_state_dict"]
+                if "std" in actor_state and "distribution.std_param" not in actor_state:
+                    actor_state["distribution.std_param"] = actor_state.pop("std")
+                self.alg.actor.load_state_dict(actor_state, strict=strict)
+            if do_load_critic and "critic_state_dict" in loaded_dict:
+                self.alg.critic.load_state_dict(
+                    loaded_dict["critic_state_dict"], strict=strict
+                )
+        else:
+            do_load_discriminator = load_cfg.get("discriminator", True)
+            if "model_state_dict" in loaded_dict:
+                self.alg.actor_critic.load_state_dict(loaded_dict["model_state_dict"])
+
+        if do_load_discriminator and "discriminator_state_dict" in loaded_dict:
+            discriminator_state = loaded_dict["discriminator_state_dict"]
+            self.alg.discriminator.load_state_dict(discriminator_state, strict=False)
 
         amp_normalizer_module = loaded_dict.get("amp_normalizer")
         if amp_normalizer_module is not None and getattr(
             self.alg.discriminator, "empirical_normalization", False
         ):
-            # Old checkpoints stored the empirical normalizer separately; hydrate it if present.
             self.alg.discriminator.amp_normalizer.load_state_dict(
                 amp_normalizer_module.state_dict()
             )
-        if load_optimizer:
+
+        if do_load_optimizer and "optimizer_state_dict" in loaded_dict:
             self.alg.optimizer.load_state_dict(loaded_dict["optimizer_state_dict"])
-        self.current_learning_iteration = loaded_dict["iter"]
-        return loaded_dict["infos"]
+        if "iter" in loaded_dict:
+            self.current_learning_iteration = loaded_dict["iter"]
+        return loaded_dict.get("infos")
 
     def get_inference_policy(self, device=None):
         self.eval_mode()  # switch to evaluation mode (dropout for example)
-        if device is not None:
-            self.alg.actor_critic.to(device)
-        return self.alg.actor_critic.act_inference
+        if RSL_RL_V4_PLUS:
+            if device is not None:
+                self.alg.actor.to(device)
+            return lambda obs: self.alg.actor(obs, stochastic_output=False)
+        else:
+            if device is not None:
+                self.alg.actor_critic.to(device)
+            return self.alg.actor_critic.act_inference
 
     def train_mode(self):
-        self.alg.actor_critic.train()
+        if RSL_RL_V4_PLUS:
+            self.alg.actor.train()
+            self.alg.critic.train()
+        else:
+            self.alg.actor_critic.train()
         self.alg.discriminator.train()
 
     def eval_mode(self):
-        self.alg.actor_critic.eval()
+        if RSL_RL_V4_PLUS:
+            self.alg.actor.eval()
+            self.alg.critic.eval()
+        else:
+            self.alg.actor_critic.eval()
         self.alg.discriminator.eval()
 
     def add_git_repo_to_log(self, repo_file_path):

--- a/amp_rsl_rl/runners/amp_on_policy_runner.py
+++ b/amp_rsl_rl/runners/amp_on_policy_runner.py
@@ -138,7 +138,7 @@ class AMPOnPolicyRunner:
     a discriminator-based "style reward" from the expert dataset. This is combined
     with the environment reward as:
 
-        `reward = 0.5 * task_reward + 0.5 * style_reward`
+        `reward = (1-<style_weight>) * task_reward + <style_weight> * style_reward`
 
     This can be later generalized into a weighted or learned reward mixing policy.
 
@@ -191,6 +191,7 @@ class AMPOnPolicyRunner:
         self.dataset_cfg = train_cfg["dataset"]
         self.device = device
         self.env = env
+        self.style_weight = train_cfg.get("style_weight", 0.5)
 
         # Optional custom exporter function (set via set_export_policy_fn)
         self._export_policy_fn: Callable | None = None
@@ -206,10 +207,15 @@ class AMPOnPolicyRunner:
             self.critic_cfg = train_cfg["critic"]
             self.policy_cfg = {}
 
-            self.actor_cfg.pop("cnn_cfg", None)
-            self.critic_cfg.pop("cnn_cfg", None)
             actor_class = resolve_class(self.actor_cfg.pop("class_name", "MLPModel"))
             critic_class = resolve_class(self.critic_cfg.pop("class_name", "MLPModel"))
+
+            # Filter config dicts to only contain kwargs accepted by the resolved class
+            import inspect
+            actor_valid_keys = set(inspect.signature(actor_class.__init__).parameters.keys())
+            critic_valid_keys = set(inspect.signature(critic_class.__init__).parameters.keys())
+            self.actor_cfg = {k: v for k, v in self.actor_cfg.items() if k in actor_valid_keys}
+            self.critic_cfg = {k: v for k, v in self.critic_cfg.items() if k in critic_valid_keys}
 
             actor = actor_class(
                 observations,
@@ -480,7 +486,7 @@ class AMPOnPolicyRunner:
                     mean_task_reward_log += rewards.mean().item()
                     mean_style_reward_log += style_rewards.mean().item()
 
-                    rewards = 0.5 * rewards + 0.5 * style_rewards
+                    rewards = (1 - self.style_weight) * rewards + self.style_weight * style_rewards
 
                     self.alg.process_env_step(obs, rewards, dones, extras)
                     self.alg.process_amp_step(next_amp_obs)

--- a/amp_rsl_rl/runners/amp_on_policy_runner.py
+++ b/amp_rsl_rl/runners/amp_on_policy_runner.py
@@ -10,6 +10,7 @@ import importlib
 import os
 import statistics
 import time
+import warnings
 from collections import deque
 from typing import Callable
 
@@ -205,7 +206,7 @@ class AMPOnPolicyRunner:
         if RSL_RL_V4_PLUS:
             self.actor_cfg = train_cfg["actor"]
             self.critic_cfg = train_cfg["critic"]
-            self.policy_cfg = {}
+            self.policy_cfg = {"actor": self.actor_cfg, "critic": self.critic_cfg}
 
             actor_class = resolve_class(self.actor_cfg.pop("class_name", "MLPModel"))
             critic_class = resolve_class(self.critic_cfg.pop("class_name", "MLPModel"))
@@ -252,9 +253,27 @@ class AMPOnPolicyRunner:
                     "asset_cfg"
                 ].joint_names
             except AttributeError:
+                warnings.warn(
+                    "Could not resolve amp_joint_names from "
+                    "env.cfg.observations.amp.joint_pos.params['asset_cfg'].joint_names. "
+                    "Falling back to None. Set 'amp_joint_names' in dataset_cfg explicitly "
+                    "to silence this warning.",
+                    stacklevel=2,
+                )
                 amp_joint_names = None
 
-        simulation_dt = self._resolve_simulation_dt()
+        sim_cfg = getattr(self.env.cfg, "sim", None)
+        if sim_cfg is None or not hasattr(sim_cfg, "dt"):
+            raise AttributeError(
+                "env.cfg.sim.dt is not set. Please ensure your environment config "
+                "defines `sim.dt` (the simulation timestep)."
+            )
+        if not hasattr(self.env.cfg, "decimation"):
+            raise AttributeError(
+                "env.cfg.decimation is not set. Please ensure your environment config "
+                "defines `decimation` (the action repeat factor)."
+            )
+        simulation_dt = self.env.cfg.sim.dt * self.env.cfg.decimation
 
         # Initialize all the ingredients required for AMP (discriminator, dataset loader)
         num_amp_obs = self._flatten_amp_obs(observations["amp"]).shape[1]
@@ -342,23 +361,6 @@ class AMPOnPolicyRunner:
             return torch.cat([amp_obs[k] for k in keys], dim=-1)
         raise TypeError(f"Unsupported AMP observation type: {type(amp_obs)}")
 
-    def _resolve_simulation_dt(self) -> float:
-        sim_cfg = getattr(self.env.cfg, "sim", None)
-        decimation = float(getattr(self.env.cfg, "decimation", 1))
-        base_dt = None
-        if sim_cfg is not None:
-            base_dt = getattr(sim_cfg, "dt", None)
-            if base_dt is None:
-                mujoco_cfg = getattr(sim_cfg, "mujoco", None)
-                if mujoco_cfg is not None:
-                    base_dt = getattr(mujoco_cfg, "timestep", None)
-        if base_dt is None:
-            raise AttributeError(
-                "Unable to resolve simulation dt from env config. Expected either "
-                "`env.cfg.sim.dt` or `env.cfg.sim.mujoco.timestep`."
-            )
-        return float(base_dt) * decimation
-
     def learn(self, num_learning_iterations: int, init_at_random_ep_len: bool = False):
         # initialize writer
         if self.log_dir is not None and self.writer is None:
@@ -419,7 +421,8 @@ class AMPOnPolicyRunner:
                 _wandb_project = self.cfg.get("wandb_project") or self.cfg.get(
                     "wandb_kwargs", {}
                 ).get("project", "")
-                update_run_name_with_sequence(prefix=_wandb_project)
+                if _wandb_project:
+                    update_run_name_with_sequence(prefix=_wandb_project)
 
                 self.writer.log_config(
                     self.env.cfg, self.cfg, self.alg_cfg, self.policy_cfg
@@ -816,8 +819,10 @@ class AMPOnPolicyRunner:
             self.alg.discriminator.load_state_dict(discriminator_state, strict=False)
 
         amp_normalizer_module = loaded_dict.get("amp_normalizer")
-        if amp_normalizer_module is not None and getattr(
-            self.alg.discriminator, "empirical_normalization", False
+        if (
+            do_load_discriminator
+            and amp_normalizer_module is not None
+            and getattr(self.alg.discriminator, "empirical_normalization", False)
         ):
             self.alg.discriminator.amp_normalizer.load_state_dict(
                 amp_normalizer_module.state_dict()

--- a/amp_rsl_rl/utils/_compat.py
+++ b/amp_rsl_rl/utils/_compat.py
@@ -22,10 +22,8 @@ def _parse_ver(ver_str: str) -> tuple:
 
 try:
     _rsl_rl_version = version("rsl-rl-lib")
-    print(f"Detected rsl-rl version: {_rsl_rl_version}")
 except PackageNotFoundError:
     _rsl_rl_version = "3.0.0"
-    print("rsl-rl not found, defaulting to version 3.0.0 for compatibility checks")
 
 _VER: tuple = _parse_ver(_rsl_rl_version)
 RSL_RL_MAJOR: int = _VER[0]

--- a/amp_rsl_rl/utils/_compat.py
+++ b/amp_rsl_rl/utils/_compat.py
@@ -3,62 +3,163 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
+"""Compatibility shim for rsl-rl-lib v3.0 through v5.x.
+
+This module detects the installed version of ``rsl-rl-lib`` and re-exports
+symbols whose locations or signatures changed across major versions:
+
++---------------------------+--------------------+--------------------+
+| Symbol                    | v3 location        | v4+/v5+ location   |
++===========================+====================+====================+
+| EmpiricalNormalization    | rsl_rl.networks    | rsl_rl.modules.    |
+|                           |                    | normalization      |
++---------------------------+--------------------+--------------------+
+| store_code_state          | rsl_rl.utils       | Logger method only |
+|                           | (standalone, <=3.1)|   (>=3.2)          |
++---------------------------+--------------------+--------------------+
+| resolve_obs_groups        | rsl_rl.utils (all) | rsl_rl.utils (all) |
++---------------------------+--------------------+--------------------+
+
+Version flags exposed:
+- ``RSL_RL_VERSION``: full version tuple (major, minor, patch).
+- ``RSL_RL_MAJOR``: integer major version.
+- ``RSL_RL_V4_PLUS``: True if major >= 4.
+- ``RSL_RL_V5_PLUS``: True if major >= 5.
+"""
+
 from __future__ import annotations
 
+import os
+import pathlib
+import warnings
 from importlib.metadata import version, PackageNotFoundError
+from typing import List
 
-import rsl_rl
 
+# ---------------------------------------------------------------------------
+# Version detection
+# ---------------------------------------------------------------------------
 
-def _parse_ver(ver_str: str) -> tuple:
-    parts = []
-    for seg in str(ver_str).split(".")[:3]:
-        digits = "".join(c for c in seg if c.isdigit())
+def _parse_version(ver_str: str) -> tuple[int, int, int]:
+    """Parse a PEP-440 version string into a (major, minor, patch) tuple."""
+    parts: list[int] = []
+    for segment in str(ver_str).split(".")[:3]:
+        digits = "".join(c for c in segment if c.isdigit())
         parts.append(int(digits) if digits else 0)
     while len(parts) < 3:
         parts.append(0)
-    return tuple(parts)
+    return (parts[0], parts[1], parts[2])
 
 
 try:
-    _rsl_rl_version = version("rsl-rl-lib")
+    _rsl_rl_version_str: str = version("rsl-rl-lib")
 except PackageNotFoundError:
-    _rsl_rl_version = "3.0.0"
+    _rsl_rl_version_str = "3.0.0"
+    warnings.warn(
+        "Could not detect rsl-rl-lib version (package not found). "
+        "Assuming v3.0.0 for compatibility.",
+        stacklevel=2,
+    )
 
-_VER: tuple = _parse_ver(_rsl_rl_version)
-RSL_RL_MAJOR: int = _VER[0]
+RSL_RL_VERSION: tuple[int, int, int] = _parse_version(_rsl_rl_version_str)
+RSL_RL_MAJOR: int = RSL_RL_VERSION[0]
 RSL_RL_V4_PLUS: bool = RSL_RL_MAJOR >= 4
 RSL_RL_V5_PLUS: bool = RSL_RL_MAJOR >= 5
 
+
+# ---------------------------------------------------------------------------
+# EmpiricalNormalization
+# ---------------------------------------------------------------------------
+# v3: rsl_rl.networks.EmpiricalNormalization
+# v4+: rsl_rl.modules.normalization.EmpiricalNormalization
+
 try:
     from rsl_rl.networks import EmpiricalNormalization  # noqa: F401
-except ImportError:
+except (ImportError, ModuleNotFoundError):
     from rsl_rl.modules.normalization import EmpiricalNormalization  # noqa: F401
+
+
+# ---------------------------------------------------------------------------
+# resolve_obs_groups  (available in all versions under rsl_rl.utils)
+# ---------------------------------------------------------------------------
 
 from rsl_rl.utils import resolve_obs_groups  # noqa: F401
 
-if RSL_RL_V4_PLUS:
-    from rsl_rl.utils.logger import Logger as _Logger
 
-    def store_code_state(log_dir: str, repos: list) -> list:
+# ---------------------------------------------------------------------------
+# store_code_state
+# ---------------------------------------------------------------------------
+# - v3.0.x / v3.1.x: standalone function in rsl_rl.utils with signature
+#       store_code_state(logdir: str, repositories: list[str]) -> list[str]
+# - v3.2+ / v4+ / v5+: removed from rsl_rl.utils; functionality moved to
+#       Logger._store_code_state(self) -> list[str] | None
+#
+# We provide a unified function with signature:
+#       store_code_state(log_dir: str, repos: list[str]) -> list[str]
+
+def _store_code_state_via_logger(log_dir: str, repos: List[str]) -> List[str]:
+    """Reimplement store_code_state using the same logic as Logger._store_code_state.
+
+    Rather than constructing a fragile Logger stub, we replicate the straightforward
+    git-diff logic that all versions use internally. This avoids depending on Logger's
+    internal state or constructor signature.
+    """
+    try:
+        import git  # GitPython — required dependency of rsl-rl-lib
+    except ImportError:
+        warnings.warn(
+            "GitPython not installed; cannot store code state.",
+            stacklevel=3,
+        )
+        return []
+
+    git_log_dir = os.path.join(log_dir, "git")
+    os.makedirs(git_log_dir, exist_ok=True)
+    file_paths: List[str] = []
+
+    for repository_file_path in repos:
         try:
-            return _Logger._store_code_state(log_dir, repos)
-        except TypeError:
-            pass
-        try:
-            stub = _Logger.__new__(_Logger)
-            stub.log_dir = log_dir
-            stub.disable_logs = False
-            stub.git_status_repos = repos
-            return _Logger._store_code_state(stub)
+            repo = git.Repo(repository_file_path, search_parent_directories=True)
+            tree = repo.head.commit.tree
+            commit_hash = repo.head.commit.hexsha
         except Exception:
-            return []
+            print(f"Could not find git repository in {repository_file_path}. Skipping.")
+            continue
 
-else:
+        repo_name = pathlib.Path(repo.working_dir).name
+        diff_file_name = os.path.join(git_log_dir, f"{repo_name}.diff")
+
+        # Don't overwrite existing diff files
+        if os.path.isfile(diff_file_name):
+            continue
+
+        print(f"Storing git diff for '{repo_name}' in: {diff_file_name}")
+        with open(diff_file_name, "x", encoding="utf-8") as f:
+            content = (
+                f"--- git commit ---\n{commit_hash}\n\n\n"
+                f"--- git status ---\n{repo.git.status()} \n\n\n"
+                f"--- git diff ---\n{repo.git.diff(tree)}"
+            )
+            f.write(content)
+        file_paths.append(diff_file_name)
+
+    return file_paths
+
+
+# Try the standalone function first (v3.0.x / v3.1.x only)
+try:
     from rsl_rl.utils import store_code_state  # noqa: F401
+except ImportError:
+    # v3.2+ / v4+ / v5+: standalone function was removed
+    store_code_state = _store_code_state_via_logger
 
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
 
 __all__ = [
+    "RSL_RL_VERSION",
     "RSL_RL_MAJOR",
     "RSL_RL_V4_PLUS",
     "RSL_RL_V5_PLUS",

--- a/amp_rsl_rl/utils/_compat.py
+++ b/amp_rsl_rl/utils/_compat.py
@@ -1,0 +1,70 @@
+# Copyright (c) 2025, Istituto Italiano di Tecnologia
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+from __future__ import annotations
+
+from importlib.metadata import version, PackageNotFoundError
+
+import rsl_rl
+
+
+def _parse_ver(ver_str: str) -> tuple:
+    parts = []
+    for seg in str(ver_str).split(".")[:3]:
+        digits = "".join(c for c in seg if c.isdigit())
+        parts.append(int(digits) if digits else 0)
+    while len(parts) < 3:
+        parts.append(0)
+    return tuple(parts)
+
+
+try:
+    _rsl_rl_version = version("rsl-rl-lib")
+    print(f"Detected rsl-rl version: {_rsl_rl_version}")
+except PackageNotFoundError:
+    _rsl_rl_version = "3.0.0"
+    print("rsl-rl not found, defaulting to version 3.0.0 for compatibility checks")
+
+_VER: tuple = _parse_ver(_rsl_rl_version)
+RSL_RL_MAJOR: int = _VER[0]
+RSL_RL_V4_PLUS: bool = RSL_RL_MAJOR >= 4
+RSL_RL_V5_PLUS: bool = RSL_RL_MAJOR >= 5
+
+try:
+    from rsl_rl.networks import EmpiricalNormalization  # noqa: F401
+except ImportError:
+    from rsl_rl.modules.normalization import EmpiricalNormalization  # noqa: F401
+
+from rsl_rl.utils import resolve_obs_groups  # noqa: F401
+
+if RSL_RL_V4_PLUS:
+    from rsl_rl.utils.logger import Logger as _Logger
+
+    def store_code_state(log_dir: str, repos: list) -> list:
+        try:
+            return _Logger._store_code_state(log_dir, repos)
+        except TypeError:
+            pass
+        try:
+            stub = _Logger.__new__(_Logger)
+            stub.log_dir = log_dir
+            stub.disable_logs = False
+            stub.git_status_repos = repos
+            return _Logger._store_code_state(stub)
+        except Exception:
+            return []
+
+else:
+    from rsl_rl.utils import store_code_state  # noqa: F401
+
+
+__all__ = [
+    "RSL_RL_MAJOR",
+    "RSL_RL_V4_PLUS",
+    "RSL_RL_V5_PLUS",
+    "EmpiricalNormalization",
+    "store_code_state",
+    "resolve_obs_groups",
+]

--- a/amp_rsl_rl/utils/exporter.py
+++ b/amp_rsl_rl/utils/exporter.py
@@ -38,16 +38,43 @@ Helper Classes - Private.
 """
 
 
+def _clone_module(module):
+    """Clone a module using state_dict to avoid deepcopy issues with non-leaf tensors."""
+    import io
+    buffer = io.BytesIO()
+    torch.save(module, buffer)
+    buffer.seek(0)
+    return torch.load(buffer, map_location='cpu', weights_only=False)
+
+
 class _TorchPolicyExporter(torch.nn.Module):
     """Exporter of actor-critic into JIT file."""
 
     def __init__(self, actor_critic, normalizer=None):
         super().__init__()
-        self.actor = copy.deepcopy(actor_critic.actor)
-        self.is_recurrent = actor_critic.is_recurrent
+        self._is_mlp_model = False
+        # Handle both ActorCritic (v3) and direct actor module (v4+)
+        if hasattr(actor_critic, 'actor'):
+            actor = actor_critic.actor
+        else:
+            actor = actor_critic
+        
+        # Check if this is an MLPModel (v4+ style with mlp attribute)
+        if hasattr(actor, 'mlp'):
+            self._is_mlp_model = True
+            # Clone using torch.save/load to avoid deepcopy issues with non-leaf tensors
+            actor_clone = _clone_module(actor)
+            self.mlp = actor_clone.mlp
+            self.distribution = actor_clone.distribution
+            self.actor = None  # Not used for MLPModel
+        else:
+            self.actor = _clone_module(actor)
+            self.mlp = None
+            self.distribution = None
+            
+        self.is_recurrent = getattr(actor_critic, 'is_recurrent', False)
         if self.is_recurrent:
-            self.rnn = copy.deepcopy(actor_critic.memory_a.rnn)
-            self.rnn.cpu()
+            self.rnn = _clone_module(actor_critic.memory_a.rnn)
             self.register_buffer(
                 "hidden_state",
                 torch.zeros(self.rnn.num_layers, 1, self.rnn.hidden_size),
@@ -59,7 +86,7 @@ class _TorchPolicyExporter(torch.nn.Module):
             self.reset = self.reset_memory
         # copy normalizer if exists
         if normalizer:
-            self.normalizer = copy.deepcopy(normalizer)
+            self.normalizer = _clone_module(normalizer)
         else:
             self.normalizer = torch.nn.Identity()
 
@@ -72,7 +99,13 @@ class _TorchPolicyExporter(torch.nn.Module):
         return self.actor(x)
 
     def forward(self, x):
-        return self.actor(self.normalizer(x))
+        x = self.normalizer(x)
+        if self._is_mlp_model:
+            mlp_output = self.mlp(x)
+            if self.distribution is not None:
+                return self.distribution.deterministic_output(mlp_output)
+            return mlp_output
+        return self.actor(x)
 
     @torch.jit.export
     def reset(self):
@@ -96,15 +129,33 @@ class _OnnxPolicyExporter(torch.nn.Module):
     def __init__(self, actor_critic, normalizer=None, verbose=False):
         super().__init__()
         self.verbose = verbose
-        self.actor = copy.deepcopy(actor_critic.actor)
-        self.is_recurrent = actor_critic.is_recurrent
+        self._is_mlp_model = False
+        # Handle both ActorCritic (v3) and direct actor module (v4+)
+        if hasattr(actor_critic, 'actor'):
+            actor = actor_critic.actor
+        else:
+            actor = actor_critic
+        
+        # Check if this is an MLPModel (v4+ style with mlp attribute)
+        if hasattr(actor, 'mlp'):
+            self._is_mlp_model = True
+            # Clone using torch.save/load to avoid deepcopy issues with non-leaf tensors
+            actor_clone = _clone_module(actor)
+            self.mlp = actor_clone.mlp
+            self.distribution = actor_clone.distribution
+            self.actor = None  # Not used for MLPModel
+        else:
+            self.actor = _clone_module(actor)
+            self.mlp = None
+            self.distribution = None
+            
+        self.is_recurrent = getattr(actor_critic, 'is_recurrent', False)
         if self.is_recurrent:
-            self.rnn = copy.deepcopy(actor_critic.memory_a.rnn)
-            self.rnn.cpu()
+            self.rnn = _clone_module(actor_critic.memory_a.rnn)
             self.forward = self.forward_lstm
         # copy normalizer if exists
         if normalizer:
-            self.normalizer = copy.deepcopy(normalizer)
+            self.normalizer = _clone_module(normalizer)
         else:
             self.normalizer = torch.nn.Identity()
 
@@ -115,7 +166,13 @@ class _OnnxPolicyExporter(torch.nn.Module):
         return self.actor(x), h, c
 
     def forward(self, x):
-        return self.actor(self.normalizer(x))
+        x = self.normalizer(x)
+        if self._is_mlp_model:
+            mlp_output = self.mlp(x)
+            if self.distribution is not None:
+                return self.distribution.deterministic_output(mlp_output)
+            return mlp_output
+        return self.actor(x)
 
     def export(self, path, filename):
         self.to("cpu")
@@ -137,11 +194,17 @@ class _OnnxPolicyExporter(torch.nn.Module):
                 dynamo=False,
             )
         else:
-            obs = (
-                torch.zeros(1, self.actor.obs_dim)
-                if isinstance(self.actor, ActorMoE)
-                else torch.zeros(1, self.actor[0].in_features)
-            )
+            # Handle ActorMoE, MLPModel (v4+), and nn.Sequential (v3)
+            if self._is_mlp_model:
+                # For MLPModel, get input dimension from the MLP's first layer
+                obs_dim = self.mlp[0].in_features
+            elif isinstance(self.actor, ActorMoE):
+                obs_dim = self.actor.obs_dim
+            elif hasattr(self.actor, 'obs_dim'):
+                obs_dim = self.actor.obs_dim
+            else:
+                obs_dim = self.actor[0].in_features
+            obs = torch.zeros(1, obs_dim)
             torch.onnx.export(
                 self,
                 obs,

--- a/amp_rsl_rl/utils/exporter.py
+++ b/amp_rsl_rl/utils/exporter.py
@@ -5,7 +5,6 @@
 #
 # Code taken from https://github.com/isaac-sim/IsaacLab/blob/5716d5600a1a0e45345bc01342a70bd81fac7889/source/isaaclab_rl/isaaclab_rl/rsl_rl/exporter.py
 
-import copy
 import os
 import torch
 from amp_rsl_rl.networks import ActorMoE
@@ -39,7 +38,7 @@ Helper Classes - Private.
 
 
 def _clone_module(module):
-    """Clone a module using state_dict to avoid deepcopy issues with non-leaf tensors."""
+    """Clone a module by pickling via torch.save/torch.load to avoid deepcopy issues with non-leaf tensors."""
     import io
     buffer = io.BytesIO()
     torch.save(module, buffer)

--- a/amp_rsl_rl/utils/wandb_utils.py
+++ b/amp_rsl_rl/utils/wandb_utils.py
@@ -26,7 +26,10 @@ class WandbSummaryWriter(RslWandbSummaryWriter):
         try:
             group = cfg['wandb_kwargs']["group"]
         except KeyError:
+            group = None
             warnings.warn("wandb_group not specified in the runner config. Using default group.")
+
+        notes = cfg.get('wandb_kwargs', {}).get('notes', None)
 
         # Initialize wandb
         wandb.init(
@@ -34,7 +37,7 @@ class WandbSummaryWriter(RslWandbSummaryWriter):
             entity=entity, 
             name=run_name,
             group=group,
-            notes=cfg['wandb_kwargs']['notes'],
+            notes=notes,
         )
 
         # Add log directory to wandb

--- a/amp_rsl_rl/utils/wandb_utils.py
+++ b/amp_rsl_rl/utils/wandb_utils.py
@@ -12,10 +12,11 @@ class WandbSummaryWriter(RslWandbSummaryWriter):
         run_name = os.path.split(log_dir)[-1]
         
         # Thanks to https://github.com/leggedrobotics/rsl_rl/pull/80/
-        try:
-            project = cfg['wandb_kwargs']["project"]
-        except KeyError:
-            raise KeyError("Please specify wandb_project in the runner config, e.g. legged_gym.") from None
+        project = cfg.get('wandb_project') or cfg.get('wandb_kwargs', {}).get('project')
+        if project is None:
+            raise KeyError(
+                "Please specify 'wandb_project' or 'wandb_kwargs.project' in the runner config."
+            ) from None
 
         try:
             entity = cfg['wandb_kwargs']["entity"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dynamic = ["version"]
 
 [project.optional-dependencies]
 examples = ["huggingface_hub"]
-mlflow = ["mlflow>=2.10.0"]
+mlflow = ["mlflow>=2.10.0", "tensorboard>=2.0.0"]
 
 [project.urls]
 Homepage = "https://github.com/gbionics/amp-rsl-rl"

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -1,0 +1,122 @@
+# Copyright (c) 2025, Istituto Italiano di Tecnologia
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Tests for amp_rsl_rl.utils._compat module.
+
+Run with:
+    python -m pytest tests/test_compat.py -v
+"""
+
+import os
+import sys
+import tempfile
+
+import pytest
+
+
+def test_version_flags():
+    """Version flags are correctly set based on installed rsl-rl-lib."""
+    from importlib.metadata import version
+
+    from amp_rsl_rl.utils._compat import (
+        RSL_RL_MAJOR,
+        RSL_RL_V4_PLUS,
+        RSL_RL_V5_PLUS,
+        RSL_RL_VERSION,
+    )
+
+    installed_version = version("rsl-rl-lib")
+    major = int(installed_version.split(".")[0])
+
+    assert RSL_RL_MAJOR == major
+    assert RSL_RL_VERSION[0] == major
+    assert RSL_RL_V4_PLUS == (major >= 4)
+    assert RSL_RL_V5_PLUS == (major >= 5)
+
+
+def test_empirical_normalization_importable():
+    """EmpiricalNormalization can be imported regardless of version."""
+    from amp_rsl_rl.utils._compat import EmpiricalNormalization
+
+    assert EmpiricalNormalization is not None
+    # It should be a class
+    assert isinstance(EmpiricalNormalization, type)
+
+
+def test_resolve_obs_groups_importable():
+    """resolve_obs_groups can be imported regardless of version."""
+    from amp_rsl_rl.utils._compat import resolve_obs_groups
+
+    assert callable(resolve_obs_groups)
+
+
+def test_store_code_state_importable():
+    """store_code_state can be imported and is callable."""
+    from amp_rsl_rl.utils._compat import store_code_state
+
+    assert callable(store_code_state)
+
+
+def test_store_code_state_on_git_repo():
+    """store_code_state produces a .diff file when pointed at a git repo."""
+    from amp_rsl_rl.utils._compat import store_code_state
+
+    # Use this repository itself as the target
+    repo_file = os.path.abspath(__file__)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        result = store_code_state(tmpdir, [repo_file])
+        assert isinstance(result, list)
+        # Should have produced at least one file
+        assert len(result) >= 1
+        for path in result:
+            assert os.path.isfile(path)
+            assert path.endswith(".diff")
+            # Check content has expected sections
+            with open(path) as f:
+                content = f.read()
+            assert "git status" in content
+            assert "git diff" in content
+
+
+def test_store_code_state_non_git_dir():
+    """store_code_state gracefully handles non-git directories."""
+    from amp_rsl_rl.utils._compat import store_code_state
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        non_git_path = os.path.join(tmpdir, "not_a_repo.py")
+        with open(non_git_path, "w") as f:
+            f.write("# dummy")
+        result = store_code_state(tmpdir, [non_git_path])
+        assert isinstance(result, list)
+        assert len(result) == 0
+
+
+def test_store_code_state_idempotent():
+    """store_code_state does not overwrite existing .diff files."""
+    from amp_rsl_rl.utils._compat import store_code_state
+
+    repo_file = os.path.abspath(__file__)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        result1 = store_code_state(tmpdir, [repo_file])
+        assert len(result1) >= 1
+        # Read content of first file
+        with open(result1[0]) as f:
+            original_content = f.read()
+        # Call again — should skip (file exists)
+        result2 = store_code_state(tmpdir, [repo_file])
+        assert len(result2) == 0
+        # Original file unchanged
+        with open(result1[0]) as f:
+            assert f.read() == original_content
+
+
+def test_all_exports():
+    """__all__ matches the actual exports."""
+    import amp_rsl_rl.utils._compat as compat
+
+    for name in compat.__all__:
+        assert hasattr(compat, name), f"Missing export: {name}"


### PR DESCRIPTION
This PR introduces runtime version detection for `rsl_rl`, allowing `amp-rsl-rl` to work with `v3`, `v4`, and `v5` of the library. 

Changes:
- New compatibility layer `_compat.py:` detects the installed `rsl_rl` version and exposes `RSL_RL_V4_PLUS` / `RSL_RL_V5_PLUS` flags. Re-exports symbols that moved between versions.
- `AMP_PPO` algorithm: handles the v4+ split of `actor_critic` into separate `actor` / `critic` modules. Adapts API calls.
- `AMPOnPolicyRunner`: constructs models via `MLPModel` (v4+) or `ActorCritic/ActorCriticRecurrent` (v3). New `_flatten_amp_obs()` helper for dict-style AMP observations. New `_resolve_simulation_dt()` with fallback for MuJoCo configs. Save/load handles both checkpoint formats (`actor_state_dict` + `critic_state_dict` vs `model_state_dict`). Extended `load()` signature with `load_cfg`, `strict`, and `map_location`. `style_weight` is now a parameter from `train_cfg`.
- Policy exporters (`exporter.py`): support v4+'s `MLPModel`  alongside v3's sequential actor. Replaced `copy.deepcopy` with serialize/deserialize cloning to avoid non-leaf tensor errors.
- Minor import fixes in `ac_moe.py` and `discriminator.py` to route through the compat layer.

Testing
- [x] Tested with MJLab + rsl_rl v5.0.1
- [ ] Not yet tested with Isaac Sim + rsl_rl v3