### PR TITLE
Fix gradient penalty computation when empirical normalization is enabled

### DIFF
--- a/amp_rsl_rl/networks/discriminator.py
+++ b/amp_rsl_rl/networks/discriminator.py
@@ -191,9 +191,9 @@ class Discriminator(nn.Module):
         lambda_: float = 10,
     ):
 
-        # Compute gradient penalty to stabilize discriminator training.
-        sample_amp_expert = tuple(self.amp_normalizer(s) for s in sample_amp_expert)
-        sample_amp_policy = tuple(self.amp_normalizer(s) for s in sample_amp_policy)
+        # Compute gradient penalty on RAW (unnormalized) inputs.
+        # compute_grad_pen normalizes internally so that the penalty
+        # measures ||∇_x D(x)||² w.r.t. the true discriminator input.
         grad_pen_loss = self.compute_grad_pen(
             expert_states=sample_amp_expert,
             policy_states=sample_amp_policy,
@@ -208,6 +208,19 @@ class Discriminator(nn.Module):
             amp_loss = self.wgan_loss(policy_d=policy_d, expert_d=expert_d)
         return amp_loss, grad_pen_loss
 
+    def _forward_detached_std(self, x: torch.Tensor) -> torch.Tensor:
+        """Forward pass with normalization and detached minibatch-std (for gradient penalty)."""
+        state, next_state = torch.split(x, self.input_dim // 2, dim=-1)
+        state = self.amp_normalizer(state)
+        next_state = self.amp_normalizer(next_state)
+        x_norm = torch.cat([state, next_state], dim=-1)
+        h = self.trunk(x_norm)
+        if self.use_minibatch_std:
+            with torch.no_grad():
+                s = self._minibatch_std_scalar(h)
+            h = torch.cat([h, s], dim=-1)
+        return self.linear(h)
+
     def compute_grad_pen(
         self,
         expert_states: tuple[torch.Tensor, torch.Tensor],
@@ -215,6 +228,10 @@ class Discriminator(nn.Module):
         lambda_: float = 10,
     ) -> torch.Tensor:
         """Computes the gradient penalty used to regularize the discriminator.
+
+        The inputs are expected to be **raw** (unnormalized) states.
+        Normalization is applied internally so the penalty measures
+        ``||∇_x D(x)||²`` w.r.t. the true discriminator input.
 
         Args:
             expert_states (tuple[Tensor, Tensor]): A tuple containing batches of expert states and expert next states.
@@ -232,12 +249,7 @@ class Discriminator(nn.Module):
             alpha = alpha.expand_as(expert)
             data = alpha * expert + (1 - alpha) * policy
             data = data.detach().requires_grad_(True)
-            h = self.trunk(data)
-            if self.use_minibatch_std:
-                with torch.no_grad():
-                    s = self._minibatch_std_scalar(h)
-                h = torch.cat([h, s], dim=-1)
-            scores = self.linear(h)
+            scores = self._forward_detached_std(data)
             grad = autograd.grad(
                 outputs=scores,
                 inputs=data,
@@ -250,14 +262,9 @@ class Discriminator(nn.Module):
         elif self.loss_type == "BCEWithLogits":
             # R1 regularizer on REAL: 0.5 * lambda * ||∇_x D(x_real)||^2
             data = expert.detach().requires_grad_(True)
-            # Compute D(x_real) with minibatch-std DETACHED,
-            # so gradients are w.r.t. the sample itself, not the batch statistics.
-            h = self.trunk(data)
-            if self.use_minibatch_std:
-                with torch.no_grad():
-                    s = self._minibatch_std_scalar(h)
-                h = torch.cat([h, s], dim=-1)
-            scores = self.linear(h)
+            # Route through the full discriminator pipeline (normalize → trunk → linear)
+            # with minibatch-std DETACHED so gradients are w.r.t. the raw input.
+            scores = self._forward_detached_std(data)
 
             grad = autograd.grad(
                 outputs=scores.sum(),


### PR DESCRIPTION
## Summary

The gradient penalty in `compute_grad_pen` was computed on **pre-normalized** inputs, causing the autograd graph to miss the normalizer's Jacobian. This PR moves normalization inside the gradient computation path so the penalty correctly measures sensitivity in the raw input space.

## The bug

In `compute_loss`, the expert/policy states were normalized **before** being passed to `compute_grad_pen`:

```python
# OLD: compute_loss
sample_amp_expert = tuple(self.amp_normalizer(s) for s in sample_amp_expert)
sample_amp_policy = tuple(self.amp_normalizer(s) for s in sample_amp_policy)
grad_pen_loss = self.compute_grad_pen(expert_states=sample_amp_expert, ...)
```

Then `compute_grad_pen` set up the autograd leaf on the already-normalized tensor:

```python
# OLD: compute_grad_pen
data = expert.detach().requires_grad_(True)  # ← leaf is x_norm
h = self.trunk(data)                         # normalizer is NOT in the graph
scores = self.linear(h)
grad = autograd.grad(scores.sum(), inputs=data, ...)
```

The `.detach().requires_grad_(True)` call **cuts the autograd graph** — everything before it (including the normalizer) is invisible to `autograd.grad`. So the gradient was computed w.r.t. the normalized tensor, not the raw input.

## What the penalty actually measured

The empirical normalizer computes:

```math
x_{\text{norm}} = \frac{x_{\text{raw}} - \mu}{\sigma}
```

By the chain rule, the full gradient of the discriminator $D$ w.r.t. the raw input is:

```math
\frac{\partial D}{\partial x_{\text{raw}}} = \frac{\partial D}{\partial x_{\text{norm}}} \cdot \frac{\partial x_{\text{norm}}}{\partial x_{\text{raw}}} = \frac{\partial D}{\partial x_{\text{norm}}} \cdot \frac{1}{\sigma}
```

The **old code** measured (per dimension $i$):

```math
\mathcal{P}_{\text{old}} = \frac{\lambda}{2} \left\| \frac{\partial D}{\partial x_{\text{norm}}} \right\|^2 = \frac{\lambda}{2} \sum_i \left( \frac{\partial D}{\partial x_{\text{norm},i}} \right)^2
```

The **new code** correctly measures:

```math
\mathcal{P}_{\text{new}} = \frac{\lambda}{2} \left\| \frac{\partial D}{\partial x_{\text{raw}}} \right\|^2 = \frac{\lambda}{2} \sum_i \left( \frac{\partial D}{\partial x_{\text{norm},i}} \cdot \frac{1}{\sigma_i} \right)^2
```

## Impact on training

1. **Overall penalty magnitude**: The old code over-penalized by a factor of ~$\sigma^2$. With typical AMP observation ranges ($\sigma \approx 5$), the effective $\lambda$ was ~25x larger than configured, over-regularizing the discriminator.

2. **Per-dimension weighting**: Observation dimensions with large variance ($\sigma_i$) had their gradients over-penalized relative to those with small variance. The new code correctly penalizes each dimension proportionally to its actual sensitivity in raw input space.

3. **Non-stationarity**: Since $\sigma$ evolves during training (running statistics), the effective penalty strength was drifting — an unintended implicit schedule on $\lambda$.

4. **When `empirical_normalization=False`**: The normalizer is `nn.Identity`, so both old and new code produce **identical** results. This fix is a no-op in that case.

> [!IMPORTANT]
> We need to test in a training loop 


cc @gbionics/team-hermes  