### PR TITLE
Add compatibility with rsl_rl v3 to v5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: 🧪 CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        rsl-rl-version: ["3.1.3", "3.3.0", "4.0.1", "5.2.0"]
+        python-version: ["3.10"]
+
+    name: rsl-rl-lib ${{ matrix.rsl-rl-version }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: 🐍 Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: 📦 Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install "rsl-rl-lib==${{ matrix.rsl-rl-version }}"
+          pip install -e ".[examples,mlflow]"
+          pip install pytest
+
+      - name: 🧪 Run tests
+        run: python -m pytest tests/ -v

--- a/amp_rsl_rl/utils/_compat.py
+++ b/amp_rsl_rl/utils/_compat.py
@@ -3,62 +3,163 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
+"""Compatibility shim for rsl-rl-lib v3.0 through v5.x.
+
+This module detects the installed version of ``rsl-rl-lib`` and re-exports
+symbols whose locations or signatures changed across major versions:
+
++---------------------------+--------------------+--------------------+
+| Symbol                    | v3 location        | v4+/v5+ location   |
++===========================+====================+====================+
+| EmpiricalNormalization    | rsl_rl.networks    | rsl_rl.modules.    |
+|                           |                    | normalization      |
++---------------------------+--------------------+--------------------+
+| store_code_state          | rsl_rl.utils       | Logger method only |
+|                           | (standalone, <=3.1)|   (>=3.2)          |
++---------------------------+--------------------+--------------------+
+| resolve_obs_groups        | rsl_rl.utils (all) | rsl_rl.utils (all) |
++---------------------------+--------------------+--------------------+
+
+Version flags exposed:
+- ``RSL_RL_VERSION``: full version tuple (major, minor, patch).
+- ``RSL_RL_MAJOR``: integer major version.
+- ``RSL_RL_V4_PLUS``: True if major >= 4.
+- ``RSL_RL_V5_PLUS``: True if major >= 5.
+"""
+
 from __future__ import annotations
 
+import os
+import pathlib
+import warnings
 from importlib.metadata import version, PackageNotFoundError
+from typing import List
 
-import rsl_rl
 
+# ---------------------------------------------------------------------------
+# Version detection
+# ---------------------------------------------------------------------------
 
-def _parse_ver(ver_str: str) -> tuple:
-    parts = []
-    for seg in str(ver_str).split(".")[:3]:
-        digits = "".join(c for c in seg if c.isdigit())
+def _parse_version(ver_str: str) -> tuple[int, int, int]:
+    """Parse a PEP-440 version string into a (major, minor, patch) tuple."""
+    parts: list[int] = []
+    for segment in str(ver_str).split(".")[:3]:
+        digits = "".join(c for c in segment if c.isdigit())
         parts.append(int(digits) if digits else 0)
     while len(parts) < 3:
         parts.append(0)
-    return tuple(parts)
+    return (parts[0], parts[1], parts[2])
 
 
 try:
-    _rsl_rl_version = version("rsl-rl-lib")
+    _rsl_rl_version_str: str = version("rsl-rl-lib")
 except PackageNotFoundError:
-    _rsl_rl_version = "3.0.0"
+    _rsl_rl_version_str = "3.0.0"
+    warnings.warn(
+        "Could not detect rsl-rl-lib version (package not found). "
+        "Assuming v3.0.0 for compatibility.",
+        stacklevel=2,
+    )
 
-_VER: tuple = _parse_ver(_rsl_rl_version)
-RSL_RL_MAJOR: int = _VER[0]
+RSL_RL_VERSION: tuple[int, int, int] = _parse_version(_rsl_rl_version_str)
+RSL_RL_MAJOR: int = RSL_RL_VERSION[0]
 RSL_RL_V4_PLUS: bool = RSL_RL_MAJOR >= 4
 RSL_RL_V5_PLUS: bool = RSL_RL_MAJOR >= 5
 
+
+# ---------------------------------------------------------------------------
+# EmpiricalNormalization
+# ---------------------------------------------------------------------------
+# v3: rsl_rl.networks.EmpiricalNormalization
+# v4+: rsl_rl.modules.normalization.EmpiricalNormalization
+
 try:
     from rsl_rl.networks import EmpiricalNormalization  # noqa: F401
-except ImportError:
+except (ImportError, ModuleNotFoundError):
     from rsl_rl.modules.normalization import EmpiricalNormalization  # noqa: F401
+
+
+# ---------------------------------------------------------------------------
+# resolve_obs_groups  (available in all versions under rsl_rl.utils)
+# ---------------------------------------------------------------------------
 
 from rsl_rl.utils import resolve_obs_groups  # noqa: F401
 
-if RSL_RL_V4_PLUS:
-    from rsl_rl.utils.logger import Logger as _Logger
 
-    def store_code_state(log_dir: str, repos: list) -> list:
+# ---------------------------------------------------------------------------
+# store_code_state
+# ---------------------------------------------------------------------------
+# - v3.0.x / v3.1.x: standalone function in rsl_rl.utils with signature
+#       store_code_state(logdir: str, repositories: list[str]) -> list[str]
+# - v3.2+ / v4+ / v5+: removed from rsl_rl.utils; functionality moved to
+#       Logger._store_code_state(self) -> list[str] | None
+#
+# We provide a unified function with signature:
+#       store_code_state(log_dir: str, repos: list[str]) -> list[str]
+
+def _store_code_state_via_logger(log_dir: str, repos: List[str]) -> List[str]:
+    """Reimplement store_code_state using the same logic as Logger._store_code_state.
+
+    Rather than constructing a fragile Logger stub, we replicate the straightforward
+    git-diff logic that all versions use internally. This avoids depending on Logger's
+    internal state or constructor signature.
+    """
+    try:
+        import git  # GitPython — required dependency of rsl-rl-lib
+    except ImportError:
+        warnings.warn(
+            "GitPython not installed; cannot store code state.",
+            stacklevel=3,
+        )
+        return []
+
+    git_log_dir = os.path.join(log_dir, "git")
+    os.makedirs(git_log_dir, exist_ok=True)
+    file_paths: List[str] = []
+
+    for repository_file_path in repos:
         try:
-            return _Logger._store_code_state(log_dir, repos)
-        except TypeError:
-            pass
-        try:
-            stub = _Logger.__new__(_Logger)
-            stub.log_dir = log_dir
-            stub.disable_logs = False
-            stub.git_status_repos = repos
-            return _Logger._store_code_state(stub)
+            repo = git.Repo(repository_file_path, search_parent_directories=True)
+            tree = repo.head.commit.tree
+            commit_hash = repo.head.commit.hexsha
         except Exception:
-            return []
+            print(f"Could not find git repository in {repository_file_path}. Skipping.")
+            continue
 
-else:
+        repo_name = pathlib.Path(repo.working_dir).name
+        diff_file_name = os.path.join(git_log_dir, f"{repo_name}.diff")
+
+        # Don't overwrite existing diff files
+        if os.path.isfile(diff_file_name):
+            continue
+
+        print(f"Storing git diff for '{repo_name}' in: {diff_file_name}")
+        with open(diff_file_name, "x", encoding="utf-8") as f:
+            content = (
+                f"--- git commit ---\n{commit_hash}\n\n\n"
+                f"--- git status ---\n{repo.git.status()} \n\n\n"
+                f"--- git diff ---\n{repo.git.diff(tree)}"
+            )
+            f.write(content)
+        file_paths.append(diff_file_name)
+
+    return file_paths
+
+
+# Try the standalone function first (v3.0.x / v3.1.x only)
+try:
     from rsl_rl.utils import store_code_state  # noqa: F401
+except ImportError:
+    # v3.2+ / v4+ / v5+: standalone function was removed
+    store_code_state = _store_code_state_via_logger
 
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
 
 __all__ = [
+    "RSL_RL_VERSION",
     "RSL_RL_MAJOR",
     "RSL_RL_V4_PLUS",
     "RSL_RL_V5_PLUS",

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -1,0 +1,122 @@
+# Copyright (c) 2025, Istituto Italiano di Tecnologia
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Tests for amp_rsl_rl.utils._compat module.
+
+Run with:
+    python -m pytest tests/test_compat.py -v
+"""
+
+import os
+import sys
+import tempfile
+
+import pytest
+
+
+def test_version_flags():
+    """Version flags are correctly set based on installed rsl-rl-lib."""
+    from importlib.metadata import version
+
+    from amp_rsl_rl.utils._compat import (
+        RSL_RL_MAJOR,
+        RSL_RL_V4_PLUS,
+        RSL_RL_V5_PLUS,
+        RSL_RL_VERSION,
+    )
+
+    installed_version = version("rsl-rl-lib")
+    major = int(installed_version.split(".")[0])
+
+    assert RSL_RL_MAJOR == major
+    assert RSL_RL_VERSION[0] == major
+    assert RSL_RL_V4_PLUS == (major >= 4)
+    assert RSL_RL_V5_PLUS == (major >= 5)
+
+
+def test_empirical_normalization_importable():
+    """EmpiricalNormalization can be imported regardless of version."""
+    from amp_rsl_rl.utils._compat import EmpiricalNormalization
+
+    assert EmpiricalNormalization is not None
+    # It should be a class
+    assert isinstance(EmpiricalNormalization, type)
+
+
+def test_resolve_obs_groups_importable():
+    """resolve_obs_groups can be imported regardless of version."""
+    from amp_rsl_rl.utils._compat import resolve_obs_groups
+
+    assert callable(resolve_obs_groups)
+
+
+def test_store_code_state_importable():
+    """store_code_state can be imported and is callable."""
+    from amp_rsl_rl.utils._compat import store_code_state
+
+    assert callable(store_code_state)
+
+
+def test_store_code_state_on_git_repo():
+    """store_code_state produces a .diff file when pointed at a git repo."""
+    from amp_rsl_rl.utils._compat import store_code_state
+
+    # Use this repository itself as the target
+    repo_file = os.path.abspath(__file__)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        result = store_code_state(tmpdir, [repo_file])
+        assert isinstance(result, list)
+        # Should have produced at least one file
+        assert len(result) >= 1
+        for path in result:
+            assert os.path.isfile(path)
+            assert path.endswith(".diff")
+            # Check content has expected sections
+            with open(path) as f:
+                content = f.read()
+            assert "git status" in content
+            assert "git diff" in content
+
+
+def test_store_code_state_non_git_dir():
+    """store_code_state gracefully handles non-git directories."""
+    from amp_rsl_rl.utils._compat import store_code_state
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        non_git_path = os.path.join(tmpdir, "not_a_repo.py")
+        with open(non_git_path, "w") as f:
+            f.write("# dummy")
+        result = store_code_state(tmpdir, [non_git_path])
+        assert isinstance(result, list)
+        assert len(result) == 0
+
+
+def test_store_code_state_idempotent():
+    """store_code_state does not overwrite existing .diff files."""
+    from amp_rsl_rl.utils._compat import store_code_state
+
+    repo_file = os.path.abspath(__file__)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        result1 = store_code_state(tmpdir, [repo_file])
+        assert len(result1) >= 1
+        # Read content of first file
+        with open(result1[0]) as f:
+            original_content = f.read()
+        # Call again — should skip (file exists)
+        result2 = store_code_state(tmpdir, [repo_file])
+        assert len(result2) == 0
+        # Original file unchanged
+        with open(result1[0]) as f:
+            assert f.read() == original_content
+
+
+def test_all_exports():
+    """__all__ matches the actual exports."""
+    import amp_rsl_rl.utils._compat as compat
+
+    for name in compat.__all__:
+        assert hasattr(compat, name), f"Missing export: {name}"


### PR DESCRIPTION
Enhance compatibility with rsl_rl versions 3, 4, and 5 by introducing a compatibility shim and adjusting the import paths.