### PR TITLE
add git utils to mlflow and rename experiments as wandb

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install "rsl-rl-lib==${{ matrix.rsl-rl-version }}"
-          pip install -e ".[examples,mlflow]"
+          pip install -e ".[examples,mlflow,wandb]"
           pip install pytest
 
       - name: 🧪 Run tests

--- a/amp_rsl_rl/runners/amp_on_policy_runner.py
+++ b/amp_rsl_rl/runners/amp_on_policy_runner.py
@@ -281,49 +281,10 @@ class AMPOnPolicyRunner:
                 )
             elif self.logger_type == "wandb":
                 from amp_rsl_rl.utils.wandb_utils import WandbSummaryWriter
-                import wandb
-
-                # Update the run name with a sequence number. This function is useful to
-                # replicate the same behaviour of rsl-rl-lib before v2.3.0
-                def update_run_name_with_sequence(prefix: str) -> None:
-                    # Retrieve the current wandb run details (project and entity)
-                    project = wandb.run.project
-                    entity = wandb.run.entity
-
-                    # Use wandb's API to list all runs in your project
-                    api = wandb.Api()
-                    runs = api.runs(f"{entity}/{project}")
-
-                    max_num = 0
-                    # Iterate through runs to extract the numeric suffix after the prefix.
-                    for run in runs:
-                        if run.name.startswith(prefix):
-                            # Extract the numeric part from the run name.
-                            numeric_suffix = run.name[
-                                len(prefix) :
-                            ]  # e.g., from "prefix564", get "564"
-                            try:
-                                run_num = int(numeric_suffix)
-                                if run_num > max_num:
-                                    max_num = run_num
-                            except ValueError:
-                                continue
-
-                    # Increment to get the new run number
-                    new_num = max_num + 1
-                    new_run_name = f"{prefix}{new_num}"
-
-                    # Update the wandb run's name
-                    wandb.run.name = new_run_name
-                    print("Updated run name to:", wandb.run.name)
 
                 self.writer = WandbSummaryWriter(
                     log_dir=self.log_dir, flush_secs=10, cfg=self.cfg
                 )
-                update_run_name_with_sequence(
-                    prefix=self.cfg["wandb_kwargs"]["project"]
-                )
-
                 self.writer.log_config(
                     self.env.cfg, self.cfg, self.alg_cfg, self.policy_cfg
                 )

--- a/amp_rsl_rl/utils/mlflow_utils.py
+++ b/amp_rsl_rl/utils/mlflow_utils.py
@@ -37,8 +37,7 @@ class MLflowSummaryWriter(SummaryWriter):
     - ``"experiment_name"`` (required): MLflow experiment name.
     - ``"tracking_uri"`` (optional): MLflow tracking URI. Falls back to the
       ``MLFLOW_TRACKING_URI`` environment variable or ``"./mlruns"``.
-    - ``"run_name"`` (optional): explicit run name; defaults to the last
-      component of *log_dir*.
+    - ``"run_name"`` (optional): explicit run name; defaults to ``experiment_name``.
     - ``"tags"`` (optional): dict of tags forwarded to ``mlflow.start_run``.
     - ``"notes"`` (optional): description string stored as the run description.
     """

--- a/amp_rsl_rl/utils/mlflow_utils.py
+++ b/amp_rsl_rl/utils/mlflow_utils.py
@@ -8,15 +8,7 @@ import re
 import warnings
 from dataclasses import asdict
 
-from torch.utils.tensorboard import SummaryWriter
-
-try:
-    import mlflow
-except ModuleNotFoundError:
-    raise ModuleNotFoundError(
-        "MLflow is required to log to MLflow. Install it with: pip install mlflow"
-    ) from None
-
+import mlflow
 from mlflow.utils.mlflow_tags import (
     MLFLOW_GIT_BRANCH,
     MLFLOW_GIT_COMMIT,
@@ -24,6 +16,7 @@ from mlflow.utils.mlflow_tags import (
     MLFLOW_GIT_REPO_URL,
     MLFLOW_GIT_DIFF,
 )
+from torch.utils.tensorboard import SummaryWriter
 
 try:
     import git as _git

--- a/amp_rsl_rl/utils/mlflow_utils.py
+++ b/amp_rsl_rl/utils/mlflow_utils.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import os
+import re
 import warnings
 from dataclasses import asdict
 
@@ -15,6 +16,19 @@ except ModuleNotFoundError:
     raise ModuleNotFoundError(
         "MLflow is required to log to MLflow. Install it with: pip install mlflow"
     ) from None
+
+from mlflow.utils.mlflow_tags import (
+    MLFLOW_GIT_BRANCH,
+    MLFLOW_GIT_COMMIT,
+    MLFLOW_GIT_DIRTY,
+    MLFLOW_GIT_REPO_URL,
+    MLFLOW_GIT_DIFF,
+)
+
+try:
+    import git as _git
+except ImportError:
+    _git = None
 
 
 class MLflowSummaryWriter(SummaryWriter):
@@ -53,20 +67,32 @@ class MLflowSummaryWriter(SummaryWriter):
         )
         mlflow.set_tracking_uri(tracking_uri)
 
-        # --- run name ---
-        run_name = mlflow_kwargs.get("run_name", os.path.split(log_dir)[-1])
+        # --- set experiment (must be done before searching runs) ---
+        mlflow.set_experiment(experiment_name)
+
+        # --- run name with auto-increment sequence ---
+        # Use run_name (if provided) as prefix, otherwise fall back to
+        # experiment_name. The prefix is appended with an incrementing number
+        # (e.g., "qdd-amp1", "qdd-amp2", ...), mirroring wandb behaviour.
+        prefix = mlflow_kwargs.get("run_name", experiment_name)
+        run_name = self._next_sequential_run_name(prefix)
 
         # --- tags / description ---
         tags = mlflow_kwargs.get("tags", {})
         notes = mlflow_kwargs.get("notes", "")
 
+        # --- inject git info into tags ---
+        git_tags = self._collect_git_tags()
+        # User-supplied tags take precedence over auto-detected ones
+        merged_tags = {**git_tags, **tags}
+
         # --- start (or resume) a run ---
-        mlflow.set_experiment(experiment_name)
         self._run = mlflow.start_run(
             run_name=run_name,
-            tags=tags,
+            tags=merged_tags,
             description=notes,
         )
+        print(f"MLflow run started: {run_name}")
 
         # Store log dir as a run param
         mlflow.log_param("log_dir", log_dir)
@@ -80,6 +106,107 @@ class MLflowSummaryWriter(SummaryWriter):
 
         # Keep track of already-logged video files (same pattern as wandb writer)
         self.video_files: list[str] = []
+
+    # ------------------------------------------------------------------
+    # Run naming helpers
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _next_sequential_run_name(prefix: str) -> str:
+        """Generate the next sequential run name for the active experiment.
+
+        Searches existing runs whose name starts with *prefix*, extracts
+        numeric suffixes, and returns ``prefix{max+1}``.
+        """
+        experiment = mlflow.get_experiment_by_name(prefix)
+        if experiment is None:
+            # First run ever in this experiment
+            return f"{prefix}1"
+
+        try:
+            runs_df = mlflow.search_runs(
+                [experiment.experiment_id],
+                output_format="pandas",
+            )
+        except Exception:
+            return f"{prefix}1"
+
+        if runs_df.empty or "tags.mlflow.runName" not in runs_df.columns:
+            return f"{prefix}1"
+
+        max_num = 0
+        pattern = re.compile(rf"^{re.escape(prefix)}(\d+)$")
+        for name in runs_df["tags.mlflow.runName"].dropna():
+            m = pattern.match(name)
+            if m:
+                num = int(m.group(1))
+                if num > max_num:
+                    max_num = num
+
+        return f"{prefix}{max_num + 1}"
+
+    # ------------------------------------------------------------------
+    # Git info helpers
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _collect_git_tags() -> dict[str, str]:
+        """Auto-detect the git repo from CWD and return MLflow-native git tags.
+
+        Returns an empty dict if gitpython is not installed or no repo is found.
+        """
+        if _git is None:
+            warnings.warn(
+                "gitpython is not installed — git info will not be logged to MLflow. "
+                "Install it with: pip install gitpython"
+            )
+            return {}
+
+        try:
+            repo = _git.Repo(os.getcwd(), search_parent_directories=True)
+        except Exception:
+            warnings.warn(
+                "Could not find a git repository from the current working directory. "
+                "Git info will not be logged to MLflow."
+            )
+            return {}
+
+        git_tags: dict[str, str] = {}
+
+        # Commit SHA
+        try:
+            git_tags[MLFLOW_GIT_COMMIT] = repo.head.commit.hexsha
+        except Exception:
+            pass
+
+        # Branch name (may fail on detached HEAD)
+        try:
+            git_tags[MLFLOW_GIT_BRANCH] = repo.active_branch.name
+        except TypeError:
+            git_tags[MLFLOW_GIT_BRANCH] = "DETACHED_HEAD"
+
+        # Dirty status
+        try:
+            git_tags[MLFLOW_GIT_DIRTY] = str(repo.is_dirty())
+        except Exception:
+            pass
+
+        # Remote URL (origin)
+        try:
+            if repo.remotes:
+                git_tags[MLFLOW_GIT_REPO_URL] = repo.remotes.origin.url
+        except Exception:
+            pass
+
+        # Diff (truncated to 5000 chars — MLflow tag value limit)
+        try:
+            diff = repo.git.diff(repo.head.commit.tree)
+            max_tag_len = 5000
+            if len(diff) > max_tag_len:
+                diff = diff[:max_tag_len] + "\n... [truncated]"
+            git_tags[MLFLOW_GIT_DIFF] = diff
+        except Exception:
+            pass
+
+        return git_tags
 
     # ------------------------------------------------------------------
     # Config helpers

--- a/amp_rsl_rl/utils/wandb_utils.py
+++ b/amp_rsl_rl/utils/wandb_utils.py
@@ -47,6 +47,11 @@ class WandbSummaryWriter(RslWandbSummaryWriter):
 
         self.video_files = []
 
+        self.update_run_name_with_sequence(
+            prefix=cfg["wandb_kwargs"]["project"]
+        )
+
+
     # To save video files to wandb explicitly
     # Thanks to https://github.com/leggedrobotics/rsl_rl/pull/84    
     def add_video_files(self, log_dir: str, step: int):
@@ -66,3 +71,38 @@ class WandbSummaryWriter(RslWandbSummaryWriter):
                             {"Video": wandb.Video(video_path, format="mp4")},
                             step = step
                         )
+
+    # Update the run name with a sequence number. This function is useful to
+    # replicate the same behaviour of rsl-rl-lib before v2.3.0
+    def update_run_name_with_sequence(self, prefix: str) -> None:
+        # Retrieve the current wandb run details (project and entity)
+        project = wandb.run.project
+        entity = wandb.run.entity
+
+        # Use wandb's API to list all runs in your project
+        api = wandb.Api()
+        runs = api.runs(f"{entity}/{project}")
+
+        max_num = 0
+        # Iterate through runs to extract the numeric suffix after the prefix.
+        for run in runs:
+            if run.name.startswith(prefix):
+                # Extract the numeric part from the run name.
+                numeric_suffix = run.name[
+                    len(prefix) :
+                ]  # e.g., from "prefix564", get "564"
+                try:
+                    run_num = int(numeric_suffix)
+                    if run_num > max_num:
+                        max_num = run_num
+                except ValueError:
+                    continue
+
+        # Increment to get the new run number
+        new_num = max_num + 1
+        new_run_name = f"{prefix}{new_num}"
+
+        # Update the wandb run's name
+        wandb.run.name = new_run_name
+        print("Updated run name to:", wandb.run.name)
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ dynamic = ["version"]
 [project.optional-dependencies]
 examples = ["huggingface_hub"]
 mlflow = ["mlflow>=2.10.0", "tensorboard>=2.0.0"]
+wandb = ["wandb", "tensorboard>=2.0.0"]
 
 [project.urls]
 Homepage = "https://github.com/gbionics/amp-rsl-rl"

--- a/tests/test_mlflow_summary_writer.py
+++ b/tests/test_mlflow_summary_writer.py
@@ -12,8 +12,10 @@ from __future__ import annotations
 
 import os
 import shutil
+import sys
 import tempfile
 from pathlib import Path
+from types import ModuleType
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -31,10 +33,31 @@ _fake_mlflow.exceptions.MlflowException = Exception  # used in except clauses
 @pytest.fixture(autouse=True)
 def _patch_mlflow(monkeypatch):
     """Ensure all tests use a mocked mlflow so no server is required."""
-    import sys
+    # Build a fake mlflow.utils.mlflow_tags module with the tag-name constants.
+    # This is required because mlflow_utils.py has a module-level
+    # `from mlflow.utils.mlflow_tags import ...` that runs on first import
+    # while sys.modules["mlflow"] is already a MagicMock (not a real package).
+    _fake_tags = ModuleType("mlflow.utils.mlflow_tags")
+    _fake_tags.MLFLOW_GIT_BRANCH = "mlflow.gitBranchName"
+    _fake_tags.MLFLOW_GIT_COMMIT = "mlflow.gitCommit"
+    _fake_tags.MLFLOW_GIT_DIRTY = "mlflow.gitDirty"
+    _fake_tags.MLFLOW_GIT_REPO_URL = "mlflow.gitRepoURL"
+    _fake_tags.MLFLOW_GIT_DIFF = "mlflow.gitDiff"
+
+    _fake_utils = ModuleType("mlflow.utils")
 
     monkeypatch.setitem(sys.modules, "mlflow", _fake_mlflow)
     monkeypatch.setitem(sys.modules, "mlflow.exceptions", _fake_mlflow.exceptions)
+    monkeypatch.setitem(sys.modules, "mlflow.utils", _fake_utils)
+    monkeypatch.setitem(sys.modules, "mlflow.utils.mlflow_tags", _fake_tags)
+    # Setting git to None causes `import git` to raise ImportError, so
+    # mlflow_utils sets _git = None and _collect_git_tags() returns {}.
+    monkeypatch.setitem(sys.modules, "git", None)
+
+    # Also evict the cached mlflow_utils module so the patched sys.modules
+    # is used when it is re-imported inside each test.
+    monkeypatch.delitem(sys.modules, "amp_rsl_rl.utils.mlflow_utils", raising=False)
+
     # Reset call tracking between tests
     _fake_mlflow.reset_mock()
     yield
@@ -87,7 +110,7 @@ class TestMLflowSummaryWriterInit:
         _fake_mlflow.set_tracking_uri.assert_called_once_with("./test_mlruns")
         _fake_mlflow.set_experiment.assert_called_once_with("test_experiment")
         _fake_mlflow.start_run.assert_called_once_with(
-            run_name="test_run",
+            run_name="test_run1",
             tags={"env": "unit_test"},
             description="Automated test run",
         )
@@ -125,10 +148,10 @@ class TestMLflowSummaryWriterInit:
             }
         }
         MLflowSummaryWriter(log_dir=tmp_log_dir, flush_secs=10, cfg=cfg)
-        expected_name = os.path.split(tmp_log_dir)[-1]
+        expected_prefix = os.path.split(tmp_log_dir)[-1]
         _fake_mlflow.start_run.assert_called_once()
         call_kwargs = _fake_mlflow.start_run.call_args
-        assert call_kwargs.kwargs["run_name"] == expected_name
+        assert call_kwargs.kwargs["run_name"].startswith(expected_prefix)
 
 
 class TestAddScalar:

--- a/tests/test_mlflow_summary_writer.py
+++ b/tests/test_mlflow_summary_writer.py
@@ -139,7 +139,7 @@ class TestMLflowSummaryWriterInit:
         MLflowSummaryWriter(log_dir=tmp_log_dir, flush_secs=10, cfg=cfg)
         _fake_mlflow.set_tracking_uri.assert_called_once_with("http://my-server:5000")
 
-    def test_run_name_defaults_to_log_dir_basename(self, tmp_log_dir: str):
+    def test_run_name_defaults_to_experiment_name(self, tmp_log_dir: str):
         from amp_rsl_rl.utils.mlflow_utils import MLflowSummaryWriter
 
         cfg: dict = {
@@ -148,7 +148,7 @@ class TestMLflowSummaryWriterInit:
             }
         }
         MLflowSummaryWriter(log_dir=tmp_log_dir, flush_secs=10, cfg=cfg)
-        expected_prefix = os.path.split(tmp_log_dir)[-1]
+        expected_prefix = cfg["mlflow_kwargs"]["experiment_name"]
         _fake_mlflow.start_run.assert_called_once()
         call_kwargs = _fake_mlflow.start_run.call_args
         assert call_kwargs.kwargs["run_name"].startswith(expected_prefix)


### PR DESCRIPTION
The changes are as follows:

1. Add git utils to collect information regarding the branch and commit
2. Rename experiments in mlflow similar to the renaming mechanism used with wandb
3. Move the wandb run renaming function to the class in `wandb_utils.py.`