### PR TITLE
fix: add rsl-rl 5.x compatibility guards

### DIFF
--- a/amp_rsl_rl/algorithms/amp_ppo.py
+++ b/amp_rsl_rl/algorithms/amp_ppo.py
@@ -14,7 +14,11 @@ import torch.optim as optim
 from tensordict import TensorDict
 
 # External modules providing the actor-critic model, storage utilities, and AMP components.
-from rsl_rl.modules import ActorCritic
+try:
+    from rsl_rl.modules import ActorCritic
+except ImportError:
+    # Use as type hint only
+    ActorCritic = object  # type: ignore[assignment,misc]
 from rsl_rl.storage import RolloutStorage
 
 from amp_rsl_rl.storage import ReplayBuffer

--- a/amp_rsl_rl/networks/ac_moe.py
+++ b/amp_rsl_rl/networks/ac_moe.py
@@ -8,7 +8,10 @@ from __future__ import annotations
 import torch
 import torch.nn as nn
 from torch.distributions import Normal
-from rsl_rl.networks import EmpiricalNormalization
+try:
+    from rsl_rl.networks import EmpiricalNormalization
+except (ImportError, ModuleNotFoundError):
+    from rsl_rl.modules import EmpiricalNormalization
 from rsl_rl.utils import resolve_nn_activation
 
 

--- a/amp_rsl_rl/networks/discriminator.py
+++ b/amp_rsl_rl/networks/discriminator.py
@@ -8,7 +8,10 @@ import torch.nn as nn
 from torch import autograd
 from torch.nn import functional as F
 
-from rsl_rl.networks import EmpiricalNormalization
+try:
+    from rsl_rl.networks import EmpiricalNormalization
+except (ImportError, ModuleNotFoundError):
+    from rsl_rl.modules import EmpiricalNormalization
 
 
 class Discriminator(nn.Module):

--- a/amp_rsl_rl/runners/amp_on_policy_runner.py
+++ b/amp_rsl_rl/runners/amp_on_policy_runner.py
@@ -18,8 +18,17 @@ from torch.utils.tensorboard import SummaryWriter as TensorboardSummaryWriter
 
 import rsl_rl
 from rsl_rl.env import VecEnv
-from rsl_rl.modules import ActorCritic, ActorCriticRecurrent
-from rsl_rl.utils import resolve_obs_groups, store_code_state
+
+try:
+    from rsl_rl.modules import ActorCritic, ActorCriticRecurrent
+except ImportError:
+    ActorCritic = object  # type: ignore[assignment,misc]
+    ActorCriticRecurrent = object  # type: ignore[assignment,misc]
+from rsl_rl.utils import resolve_obs_groups
+try:
+    from rsl_rl.utils import store_code_state
+except ImportError:
+    store_code_state = None  # type: ignore[assignment]
 
 import amp_rsl_rl
 from amp_rsl_rl.utils import AMPLoader
@@ -444,7 +453,7 @@ class AMPOnPolicyRunner:
             ep_infos.clear()
             if it == start_iter:
                 # obtain all the diff files
-                git_file_paths = store_code_state(self.log_dir, self.git_status_repos)
+                git_file_paths = store_code_state(self.log_dir, self.git_status_repos) if store_code_state is not None else []
                 # if possible store them to wandb
                 if (
                     self.logger_type in ["wandb", "neptune", "mlflow"]


### PR DESCRIPTION
Partially supersedes #60, only handles v5