### PR TITLE
Refactor dataset loader to support multi-source datasets

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,23 @@ The AMP-RSL-RL framework expects motion capture datasets in `.npy` format. Each 
 - **`fps`**: `float`  
   The number of frames per second in the original dataset. This is used to resample the data to match the simulator's timestep.
 
+---
+
+## � Symmetry Augmentation
+AMP-RSL-RL now exposes the symmetry-aware data augmentation and mirror-loss hooks from
+[RSL-RL](https://github.com/leggedrobotics/rsl_rl). The implementation follows the design
+described in:
+> Mittal, M., Rudin, N., Klemm, V., Allshire, A., & Hutter, M. (2024).<br>
+> *Symmetry Considerations for Learning Task Symmetric Robot Policies*. In IEEE International Conference on Robotics and Automation (ICRA).<br>
+> https://doi.org/10.1109/ICRA57147.2024.10611493
+Symmetry augmentation can be enabled through the `symmetry_cfg` section of the algorithm
+configuration, providing both minibatch augmentation and optional mirror-loss regularisation
+for the policy update. AMP-specific components (the discriminator and expert/policy motion
+buffers) are augmented using the same configuration so that style rewards and adversarial
+training remain consistent with their symmetric counterparts.
+
+---
+
 ### Example
 
 Here’s an example of how the structure might look when loaded in Python:

--- a/amp_rsl_rl/algorithms/amp_ppo.py
+++ b/amp_rsl_rl/algorithms/amp_ppo.py
@@ -6,18 +6,20 @@
 
 from __future__ import annotations
 
-from typing import Optional, Tuple, Dict, Any
+import inspect
+from typing import Optional, Tuple, Dict, Any, Union, Sequence
 
 import torch
 import torch.nn as nn
 import torch.optim as optim
 from tensordict import TensorDict
 
+from rsl_rl.utils import string_to_callable
 from rsl_rl.storage import RolloutStorage
 
 from amp_rsl_rl.storage import ReplayBuffer
 from amp_rsl_rl.networks import Discriminator
-from amp_rsl_rl.utils import AMPLoader
+from amp_rsl_rl.utils import AMPLoader, _call_augmentation_func
 from amp_rsl_rl.utils._compat import RSL_RL_V4_PLUS, RSL_RL_V5_PLUS
 
 
@@ -63,6 +65,10 @@ class AMP_PPO:
         Size of the replay buffer storing policy-generated AMP samples.
     use_smooth_ratio_clipping : bool, default=False
         Enables smooth ratio clipping instead of hard clamping.
+    normalize_advantage_per_mini_batch : bool, default=False
+        Whether to normalize advantages within each mini-batch (instead of the entire rollout).
+    symmetry_cfg : dict | None, default=None
+        Configuration dictionary enabling symmetry-based data augmentation and mirror loss.
     device : str, default="cpu"
         Torch device used by the module.
     """
@@ -88,6 +94,8 @@ class AMP_PPO:
         desired_kl: float = 0.01,
         amp_replay_buffer_size: int = 100000,
         use_smooth_ratio_clipping: bool = False,
+        normalize_advantage_per_mini_batch: bool = False,
+        symmetry_cfg: Optional[Dict[str, Any]] = None,
         device: str = "cpu",
     ) -> None:
         # Set device and learning hyperparameters
@@ -95,6 +103,9 @@ class AMP_PPO:
         self.desired_kl: float = desired_kl
         self.schedule: str = schedule
         self.learning_rate: float = learning_rate
+        self.normalize_advantage_per_mini_batch: bool = (
+            normalize_advantage_per_mini_batch
+        )
 
         if RSL_RL_V4_PLUS:
             if actor is None or critic is None:
@@ -174,6 +185,32 @@ class AMP_PPO:
         self.use_clipped_value_loss: bool = use_clipped_value_loss
         self.use_smooth_ratio_clipping: bool = use_smooth_ratio_clipping
 
+        # Symmetry configuration for PPO and AMP augmentation
+        self.symmetry: Optional[Dict[str, Any]] = None
+        if symmetry_cfg is not None:
+            use_symmetry = symmetry_cfg.get(
+                "use_data_augmentation", False
+            ) or symmetry_cfg.get("use_mirror_loss", False)
+            if not use_symmetry:
+                print(
+                    "Symmetry configuration provided but neither data augmentation nor mirror loss are enabled."
+                    " Symmetry utilities will only be available for logging."
+                )
+            aug_fn = symmetry_cfg.get("data_augmentation_func")
+            if isinstance(aug_fn, str):
+                symmetry_cfg["data_augmentation_func"] = string_to_callable(aug_fn)
+            aug_fn = symmetry_cfg.get("data_augmentation_func")
+            if aug_fn is not None and not callable(aug_fn):
+                raise ValueError(
+                    "Symmetry configuration exists but the function is not callable: "
+                    f"{aug_fn}"
+                )
+            if getattr(actor_critic, "is_recurrent", False):
+                raise ValueError(
+                    "Symmetry augmentation is not supported for recurrent policies in AMP_PPO."
+                )
+            self.symmetry = symmetry_cfg
+
     def init_storage(
         self,
         num_envs: int,
@@ -201,6 +238,59 @@ class AMP_PPO:
             obs=observations,
             actions_shape=action_shape,
             device=self.device,
+        )
+
+    def _augment_batch_size(
+        self, original_size: int, augmented: Optional[torch.Tensor]
+    ) -> int:
+        """Compute augmentation factor given the original and augmented batch sizes."""
+
+        if augmented is None or original_size == 0:
+            return 1
+        if augmented.shape[0] % original_size != 0:
+            raise ValueError(
+                "Symmetry augmentation function returned a batch size incompatible with the original size."
+                f" Original={original_size}, augmented={augmented.shape[0]}"
+            )
+        return augmented.shape[0] // original_size
+
+    def _repeat_along_batch(
+        self, tensor: Optional[torch.Tensor], num_aug: int
+    ) -> Optional[torch.Tensor]:
+        """Repeat a tensor along the first dimension to match augmentation factor."""
+
+        if tensor is None or num_aug == 1:
+            return tensor
+        repeat_dims = [num_aug] + [1] * (tensor.dim() - 1)
+        return tensor.repeat(*repeat_dims)
+
+    def _apply_symmetry(
+        self,
+        *,
+        obs: Optional[torch.Tensor],
+        actions: Optional[torch.Tensor],
+        obs_type: Union[str, Sequence[str]] = None,
+    ) -> Tuple[Optional[torch.Tensor], Optional[torch.Tensor]]:
+        """Apply configured symmetry augmentation to observations/actions."""
+
+        if self.symmetry is None:
+            return obs, actions
+
+        aug_fn = self.symmetry.get("data_augmentation_func")
+        if aug_fn is None:
+            return obs, actions
+
+        aug_obs, aug_actions = _call_augmentation_func(
+            aug_fn,
+            obs=obs,
+            actions=actions,
+            env=self.symmetry.get("_env"),
+            obs_type=obs_type,
+        )
+
+        return (
+            aug_obs if aug_obs is not None else obs,
+            aug_actions if aug_actions is not None else actions,
         )
 
     def test_mode(self) -> None:
@@ -349,7 +439,9 @@ class AMP_PPO:
             advantage = 0
             for step in reversed(range(st.num_transitions_per_env)):
                 next_values = (
-                    last_values if step == st.num_transitions_per_env - 1 else st.values[step + 1]
+                    last_values
+                    if step == st.num_transitions_per_env - 1
+                    else st.values[step + 1]
                 )
                 next_is_not_terminal = 1.0 - st.dones[step].float()
                 delta = (
@@ -357,7 +449,9 @@ class AMP_PPO:
                     + next_is_not_terminal * self.gamma * next_values
                     - st.values[step]
                 )
-                advantage = delta + next_is_not_terminal * self.gamma * self.lam * advantage
+                advantage = (
+                    delta + next_is_not_terminal * self.gamma * self.lam * advantage
+                )
                 st.returns[step] = advantage + st.values[step]
             st.advantages = st.returns - st.values
             st.advantages = (st.advantages - st.advantages.mean()) / (
@@ -369,7 +463,7 @@ class AMP_PPO:
 
     def update(
         self,
-    ) -> Tuple[float, float, float, float, float, float, float, float, float]:
+    ) -> Tuple[float, float, float, float, float, float, float, float, float, float]:
         """
         Performs a single update step for both the actor-critic (PPO) and the AMP discriminator.
         It iterates over mini-batches of data, computes surrogate, value, AMP and gradient penalty losses,
@@ -381,7 +475,7 @@ class AMP_PPO:
             A tuple containing mean losses and statistics:
             (mean_value_loss, mean_surrogate_loss, mean_amp_loss, mean_grad_pen_loss,
              mean_policy_pred, mean_expert_pred, mean_accuracy_policy, mean_accuracy_expert,
-             mean_kl_divergence)
+             mean_kl_divergence, mean_symmetry_loss)
         """
         # Initialize mean loss and accuracy statistics.
         mean_value_loss: float = 0.0
@@ -395,9 +489,14 @@ class AMP_PPO:
         mean_accuracy_policy_elem: float = 0.0
         mean_accuracy_expert_elem: float = 0.0
         mean_kl_divergence: float = 0.0
+        mean_symmetry_loss: float = 0.0
 
         # Create data generators for mini-batch sampling.
-        _is_recurrent = self.actor.is_recurrent if RSL_RL_V4_PLUS else self.actor_critic.is_recurrent
+        _is_recurrent = (
+            self.actor.is_recurrent
+            if RSL_RL_V4_PLUS
+            else self.actor_critic.is_recurrent
+        )
 
         if _is_recurrent:
             generator = self.storage.recurrent_mini_batch_generator(
@@ -474,6 +573,34 @@ class AMP_PPO:
             if hidden_states_batch is not None:
                 hidden_state_actor, hidden_state_critic = hidden_states_batch
 
+            original_batch_size = obs_batch.shape[0]
+
+            if self.normalize_advantage_per_mini_batch:
+                with torch.no_grad():
+                    advantages_batch = (advantages_batch - advantages_batch.mean()) / (
+                        advantages_batch.std() + 1e-8
+                    )
+
+            # Symmetry data augmentation for PPO inputs
+            if self.symmetry and self.symmetry.get("use_data_augmentation", False):
+                aug_obs, aug_actions = self._apply_symmetry(
+                    obs=obs_batch,
+                    actions=actions_batch,
+                    obs_type=["policy", "critic"],
+                )
+                num_aug = self._augment_batch_size(original_batch_size, aug_obs)
+                obs_batch = aug_obs
+                actions_batch = aug_actions
+
+                old_actions_log_prob_batch = self._repeat_along_batch(
+                    old_actions_log_prob_batch, num_aug
+                )
+                target_values_batch = self._repeat_along_batch(
+                    target_values_batch, num_aug
+                )
+                advantages_batch = self._repeat_along_batch(advantages_batch, num_aug)
+                returns_batch = self._repeat_along_batch(returns_batch, num_aug)
+
             # Forward pass through the actor to get current policy outputs.
             if RSL_RL_V4_PLUS:
                 _ = self.actor(
@@ -488,25 +615,27 @@ class AMP_PPO:
                 )
                 if hasattr(self.actor, "get_distribution_params"):
                     dist_params = self.actor.get_distribution_params()
-                    mu_batch = dist_params[0]
-                    sigma_batch = dist_params[1]
-                    entropy_batch = self.actor.get_entropy()
+                    mu_batch = dist_params[0][:original_batch_size]
+                    sigma_batch = dist_params[1][:original_batch_size]
+                    entropy_batch = self.actor.get_entropy()[:original_batch_size]
                 else:
-                    mu_batch = self.actor.output_mean
-                    sigma_batch = self.actor.output_std
-                    entropy_batch = self.actor.output_entropy
+                    mu_batch = self.actor.output_mean[:original_batch_size]
+                    sigma_batch = self.actor.output_std[:original_batch_size]
+                    entropy_batch = self.actor.output_entropy[:original_batch_size]
             else:
                 # v3
                 self.actor_critic.act(
                     obs_batch, masks=masks_batch, hidden_states=hidden_state_actor
                 )
-                actions_log_prob_batch = self.actor_critic.get_actions_log_prob(actions_batch)
+                actions_log_prob_batch = self.actor_critic.get_actions_log_prob(
+                    actions_batch
+                )
                 value_batch = self.actor_critic.evaluate(
                     obs_batch, masks=masks_batch, hidden_states=hidden_state_critic
                 )
-                mu_batch = self.actor_critic.action_mean
-                sigma_batch = self.actor_critic.action_std
-                entropy_batch = self.actor_critic.entropy
+                mu_batch = self.actor_critic.action_mean[:original_batch_size]
+                sigma_batch = self.actor_critic.action_std[:original_batch_size]
+                entropy_batch = self.actor_critic.entropy[:original_batch_size]
 
             # Adaptive learning rate adjustment based on KL divergence if schedule is "adaptive".
             if self.desired_kl is not None and self.schedule == "adaptive":
@@ -572,9 +701,60 @@ class AMP_PPO:
                 - self.entropy_coef * entropy_batch.mean()
             )
 
+            # Mirror loss (if enabled)
+            symmetry_loss_value = torch.zeros(1, device=self.device)
+            if self.symmetry:
+                if not self.symmetry.get("use_data_augmentation", False):
+                    sym_obs_batch, _ = self._apply_symmetry(
+                        obs=obs_batch[:original_batch_size],
+                        actions=None,
+                        obs_type="policy",
+                    )
+                else:
+                    sym_obs_batch = obs_batch
+
+                if sym_obs_batch is not None:
+                    with torch.no_grad():
+                        sym_obs_detached = sym_obs_batch.detach().clone()
+                    mean_actions_batch = self.actor_critic.act_inference(
+                        sym_obs_detached
+                    )
+                    action_mean_orig = mean_actions_batch[:original_batch_size]
+                    _, sym_actions = self._apply_symmetry(
+                        obs=None,
+                        actions=action_mean_orig,
+                        obs_type="policy",
+                    )
+                    if sym_actions is None:
+                        sym_actions = mean_actions_batch
+                    mse_loss = torch.nn.MSELoss()
+                    symmetry_loss_value = mse_loss(
+                        mean_actions_batch[original_batch_size:],
+                        sym_actions.detach()[original_batch_size:],
+                    )
+                    if self.symmetry.get("use_mirror_loss", False):
+                        coeff = self.symmetry.get("mirror_loss_coeff", 0.0)
+                        ppo_loss = ppo_loss + coeff * symmetry_loss_value
+                    else:
+                        symmetry_loss_value = symmetry_loss_value.detach()
+
             # Process AMP loss by unpacking policy and expert AMP samples.
             policy_state, policy_next_state = sample_amp_policy
             expert_state, expert_next_state = sample_amp_expert
+
+            if self.symmetry and self.symmetry.get("use_data_augmentation", False):
+                policy_state = self.discriminator.apply_symmetry(
+                    policy_state, obs_type="amp"
+                )
+                policy_next_state = self.discriminator.apply_symmetry(
+                    policy_next_state, obs_type="amp"
+                )
+                expert_state = self.discriminator.apply_symmetry(
+                    expert_state, obs_type="amp"
+                )
+                expert_next_state = self.discriminator.apply_symmetry(
+                    expert_next_state, obs_type="amp"
+                )
 
             # Ensure everything is on the right device (AMPLoader may yield CPU tensors)
             policy_state = policy_state.to(self.device)
@@ -622,7 +802,9 @@ class AMP_PPO:
                 nn.utils.clip_grad_norm_(self.actor.parameters(), self.max_grad_norm)
                 nn.utils.clip_grad_norm_(self.critic.parameters(), self.max_grad_norm)
             else:
-                nn.utils.clip_grad_norm_(self.actor_critic.parameters(), self.max_grad_norm)
+                nn.utils.clip_grad_norm_(
+                    self.actor_critic.parameters(), self.max_grad_norm
+                )
             self.optimizer.step()
 
             # Update the normalizer with RAW (unnormalized) observations under no_grad
@@ -644,6 +826,7 @@ class AMP_PPO:
             mean_grad_pen_loss += grad_pen_loss.item()
             mean_policy_pred += policy_d_prob.mean().item()
             mean_expert_pred += expert_d_prob.mean().item()
+            mean_symmetry_loss += symmetry_loss_value.item()
 
             # Calculate the accuracy of the discriminator.
             mean_accuracy_policy += torch.sum(
@@ -668,6 +851,7 @@ class AMP_PPO:
         mean_accuracy_policy /= max(1, mean_accuracy_policy_elem)
         mean_accuracy_expert /= max(1, mean_accuracy_expert_elem)
         mean_kl_divergence /= num_updates
+        mean_symmetry_loss /= num_updates
 
         # Clear the storage for the next update cycle.
         self.storage.clear()
@@ -682,4 +866,5 @@ class AMP_PPO:
             mean_accuracy_policy,
             mean_accuracy_expert,
             mean_kl_divergence,
+            mean_symmetry_loss,
         )

--- a/amp_rsl_rl/networks/discriminator.py
+++ b/amp_rsl_rl/networks/discriminator.py
@@ -3,10 +3,14 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
+import inspect
+from typing import Any, Dict, Optional
+
 import torch
 import torch.nn as nn
 from torch import autograd
 from torch.nn import functional as F
+from rsl_rl.utils import utils
 from amp_rsl_rl.utils._compat import EmpiricalNormalization
 
 
@@ -39,6 +43,7 @@ class Discriminator(nn.Module):
         eta_wgan: float = 0.3,
         use_minibatch_std: bool = True,
         empirical_normalization: bool = False,
+        symmetry_cfg: Optional[Dict[str, Any]] = None,
     ):
         super().__init__()
 
@@ -46,6 +51,7 @@ class Discriminator(nn.Module):
         self.input_dim = input_dim
         self.reward_scale = reward_scale
         self.reward_clamp_epsilon = reward_clamp_epsilon
+        self.symmetry_cfg = symmetry_cfg
         layers = []
         curr_in_dim = input_dim
 
@@ -79,6 +85,35 @@ class Discriminator(nn.Module):
             raise ValueError(
                 f"Unsupported loss type: {self.loss_type}. Supported types are 'BCEWithLogits' and 'Wasserstein'."
             )
+
+        if self.symmetry_cfg is not None:
+            fn = self.symmetry_cfg.get("amp_dataset_augmentation_func")
+            if isinstance(fn, str):
+                self.symmetry_cfg["amp_dataset_augmentation_func"] = (
+                    utils.string_to_callable(fn)
+                )
+
+    def apply_symmetry(
+        self, tensor: torch.Tensor, obs_type: str = "amp"
+    ) -> torch.Tensor:
+        if self.symmetry_cfg is None or self.symmetry_cfg.get(
+            "use_amp_dataset_augmentation", False
+        ):
+            return tensor
+
+        fn = self.symmetry_cfg.get("amp_dataset_augmentation_func")
+        if fn is None:
+            return tensor
+
+        augmented, _ = utils.call_augmentation_func(
+            fn,
+            obs=tensor,
+            actions=None,
+            env=self.symmetry_cfg.get("_env"),
+            obs_type=obs_type,
+        )
+
+        return augmented if augmented is not None else tensor
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         """Forward pass through the discriminator.

--- a/amp_rsl_rl/runners/amp_on_policy_runner.py
+++ b/amp_rsl_rl/runners/amp_on_policy_runner.py
@@ -108,8 +108,7 @@ class AMPOnPolicyRunner:
     - "algorithm": configuration for PPO/AMP_PPO, including `"class_name"`
     - "discriminator": configuration for the AMP discriminator
     - "dataset": dictionary forwarded to `AMPLoader`, containing at least:
-        * "amp_data_path": folder with the `.npy` expert datasets
-        * "datasets": mapping of dataset name -> sampling weight (floats)
+        * "sources": list of {dataset_path, motions} dicts
         * "slow_down_factor": slowdown applied to real motion data to match sim dynamics
         * "velocity_representation": (optional) "body_fixed" or "mixed" — frame convention
           for base velocities in discriminator observations. Default: "body_fixed"
@@ -291,13 +290,12 @@ class AMPOnPolicyRunner:
 
         amp_data = AMPLoader(
             device=self.device,
-            dataset_path_root=self.dataset_cfg["amp_data_path"],
-            datasets=self.dataset_cfg["datasets"],
             simulation_dt=simulation_dt,
             slow_down_factor=self.dataset_cfg["slow_down_factor"],
             expected_joint_names=amp_joint_names,
             velocity_representation=velocity_representation,
             symmetry_cfg=self.alg_cfg.get("symmetry_cfg"),
+            sources=self.dataset_cfg["sources"],
         )
 
         self.discriminator = Discriminator(

--- a/amp_rsl_rl/runners/amp_on_policy_runner.py
+++ b/amp_rsl_rl/runners/amp_on_policy_runner.py
@@ -21,7 +21,7 @@ import rsl_rl
 from rsl_rl.env import VecEnv
 
 import amp_rsl_rl
-from amp_rsl_rl.utils import AMPLoader
+from amp_rsl_rl.utils import AMPLoader, VelocityRepresentation
 from amp_rsl_rl.algorithms import AMP_PPO
 from amp_rsl_rl.networks import Discriminator, ActorCriticMoE
 from amp_rsl_rl.utils import export_policy_as_onnx
@@ -111,6 +111,8 @@ class AMPOnPolicyRunner:
         * "amp_data_path": folder with the `.npy` expert datasets
         * "datasets": mapping of dataset name -> sampling weight (floats)
         * "slow_down_factor": slowdown applied to real motion data to match sim dynamics
+        * "velocity_representation": (optional) "body_fixed" or "mixed" — frame convention
+          for base velocities in discriminator observations. Default: "body_fixed"
     - "num_steps_per_env": rollout horizon per environment
     - "save_interval": frequency (in iterations) for model checkpointing
     - "empirical_normalization": (deprecated) legacy flag mirrored to `policy.actor_obs_normalization`
@@ -282,6 +284,11 @@ class AMPOnPolicyRunner:
 
         # Initialize all the ingredients required for AMP (discriminator, dataset loader)
         num_amp_obs = self._flatten_amp_obs(observations["amp"]).shape[1]
+
+        # Resolve velocity representation for discriminator observations
+        vel_repr_str = self.dataset_cfg.get("velocity_representation", "body_fixed")
+        velocity_representation = VelocityRepresentation(vel_repr_str)
+
         amp_data = AMPLoader(
             device=self.device,
             dataset_path_root=self.dataset_cfg["amp_data_path"],
@@ -289,6 +296,7 @@ class AMPOnPolicyRunner:
             simulation_dt=simulation_dt,
             slow_down_factor=self.dataset_cfg["slow_down_factor"],
             expected_joint_names=amp_joint_names,
+            velocity_representation=velocity_representation,
             symmetry_cfg=self.alg_cfg.get("symmetry_cfg"),
         )
 

--- a/amp_rsl_rl/runners/amp_on_policy_runner.py
+++ b/amp_rsl_rl/runners/amp_on_policy_runner.py
@@ -108,8 +108,7 @@ class AMPOnPolicyRunner:
     - "algorithm": configuration for PPO/AMP_PPO, including `"class_name"`
     - "discriminator": configuration for the AMP discriminator
     - "dataset": dictionary forwarded to `AMPLoader`, containing at least:
-        * "amp_data_path": folder with the `.npy` expert datasets
-        * "datasets": mapping of dataset name -> sampling weight (floats)
+        * "sources": list of {dataset_path, motions} dicts
         * "slow_down_factor": slowdown applied to real motion data to match sim dynamics
     - "num_steps_per_env": rollout horizon per environment
     - "save_interval": frequency (in iterations) for model checkpointing
@@ -279,11 +278,10 @@ class AMPOnPolicyRunner:
         num_amp_obs = self._flatten_amp_obs(observations["amp"]).shape[1]
         amp_data = AMPLoader(
             device=self.device,
-            dataset_path_root=self.dataset_cfg["amp_data_path"],
-            datasets=self.dataset_cfg["datasets"],
             simulation_dt=simulation_dt,
             slow_down_factor=self.dataset_cfg["slow_down_factor"],
             expected_joint_names=amp_joint_names,
+            sources=self.dataset_cfg["sources"],
         )
 
         self.discriminator = Discriminator(

--- a/amp_rsl_rl/runners/amp_on_policy_runner.py
+++ b/amp_rsl_rl/runners/amp_on_policy_runner.py
@@ -194,6 +194,11 @@ class AMPOnPolicyRunner:
         self.env = env
         self.style_weight = train_cfg.get("style_weight", 0.5)
 
+        # if using symmetry then pass the environment config object
+        if "symmetry_cfg" in self.alg_cfg and self.alg_cfg["symmetry_cfg"] is not None:
+            # this is used by the symmetry function for handling different observation terms
+            self.alg_cfg["symmetry_cfg"]["_env"] = env
+
         # Optional custom exporter function (set via set_export_policy_fn)
         self._export_policy_fn: Callable | None = None
 
@@ -284,6 +289,7 @@ class AMPOnPolicyRunner:
             simulation_dt=simulation_dt,
             slow_down_factor=self.dataset_cfg["slow_down_factor"],
             expected_joint_names=amp_joint_names,
+            symmetry_cfg=self.alg_cfg.get("symmetry_cfg"),
         )
 
         self.discriminator = Discriminator(
@@ -293,6 +299,7 @@ class AMPOnPolicyRunner:
             device=self.device,
             loss_type=self.discriminator_cfg["loss_type"],
             empirical_normalization=self.discriminator_cfg["empirical_normalization"],
+            symmetry_cfg=self.alg_cfg.get("symmetry_cfg"),
         ).to(self.device)
 
         # Initialize the PPO algorithm
@@ -492,6 +499,7 @@ class AMPOnPolicyRunner:
                 mean_accuracy_policy,
                 mean_accuracy_expert,
                 mean_kl_divergence,
+                mean_symmetry_loss,
             ) = self.alg.update()
             stop = time.time()
             learn_time = stop - start
@@ -583,6 +591,7 @@ class AMPOnPolicyRunner:
         self.writer.add_scalar(
             "Loss/mean_kl_divergence", locs["mean_kl_divergence"], locs["it"]
         )
+        self.writer.add_scalar("Loss/symmetry", locs["mean_symmetry_loss"], locs["it"])
         self.writer.add_scalar(
             "Policy/mean_noise_std", mean_std_value.item(), locs["it"]
         )
@@ -633,6 +642,7 @@ class AMPOnPolicyRunner:
                             'collection_time']:.3f}s, learning {locs['learn_time']:.3f}s)\n"""
                 f"""{'Value function loss:':>{pad}} {locs['mean_value_loss']:.4f}\n"""
                 f"""{'Surrogate loss:':>{pad}} {locs['mean_surrogate_loss']:.4f}\n"""
+                f"""{'Symmetry loss:':>{pad}} {locs['mean_symmetry_loss']:.4f}\n"""
                 f"""{'Mean action noise std:':>{pad}} {mean_std_value.item():.2f}\n"""
                 f"""{'Mean reward:':>{pad}} {statistics.mean(locs['rewbuffer']):.2f}\n"""
                 f"""{'Mean episode length:':>{pad}} {statistics.mean(locs['lenbuffer']):.2f}\n"""
@@ -647,6 +657,7 @@ class AMPOnPolicyRunner:
                             'collection_time']:.3f}s, learning {locs['learn_time']:.3f}s)\n"""
                 f"""{'Value function loss:':>{pad}} {locs['mean_value_loss']:.4f}\n"""
                 f"""{'Surrogate loss:':>{pad}} {locs['mean_surrogate_loss']:.4f}\n"""
+                f"""{'Symmetry loss:':>{pad}} {locs['mean_symmetry_loss']:.4f}\n"""
                 f"""{'Mean action noise std:':>{pad}} {mean_std_value.item():.2f}\n"""
             )
             #   f"""{'Mean reward/step:':>{pad}} {locs['mean_reward']:.2f}\n"""

--- a/amp_rsl_rl/utils/__init__.py
+++ b/amp_rsl_rl/utils/__init__.py
@@ -10,11 +10,13 @@ from .motion_loader import (
     AMPLoader,
     download_amp_dataset_from_hf,
     _call_augmentation_func,
+    VelocityRepresentation
 )
 from .exporter import export_policy_as_onnx
 
 __all__ = [
     "AMPLoader",
+    "VelocityRepresentation",
     "download_amp_dataset_from_hf",
     "_call_augmentation_func",
     "export_policy_as_onnx",

--- a/amp_rsl_rl/utils/__init__.py
+++ b/amp_rsl_rl/utils/__init__.py
@@ -6,11 +6,16 @@
 
 """Utilities for amp"""
 
-from .motion_loader import AMPLoader, download_amp_dataset_from_hf
+from .motion_loader import (
+    AMPLoader,
+    download_amp_dataset_from_hf,
+    _call_augmentation_func,
+)
 from .exporter import export_policy_as_onnx
 
 __all__ = [
     "AMPLoader",
     "download_amp_dataset_from_hf",
+    "_call_augmentation_func",
     "export_policy_as_onnx",
 ]

--- a/amp_rsl_rl/utils/motion_loader.py
+++ b/amp_rsl_rl/utils/motion_loader.py
@@ -269,8 +269,8 @@ class AMPLoader:
 
     Args:
         device: Target torch device ('cpu' or 'cuda')
-        dataset_path_root: Directory containing the .npy motion files
-        datasets: Dictionary mapping dataset names (without extension) to sampling weights (floats)
+        sources: List of dicts, each with "dataset_path" and "motions" keys.
+            Supports loading motions from multiple directories.
         simulation_dt: Timestep used by the simulator
         slow_down_factor: Integer factor to slow down original data
         expected_joint_names: (Optional) override for joint ordering
@@ -279,13 +279,13 @@ class AMPLoader:
     def __init__(
         self,
         device: str,
-        dataset_path_root: Path,
-        datasets: Dict[str, float],
         simulation_dt: float,
         slow_down_factor: int,
         expected_joint_names: Union[List[str], None] = None,
         symmetry_cfg: Optional[Dict[str, Any]] = None,
         velocity_representation: VelocityRepresentation = VelocityRepresentation.BODY_FIXED_REPRESENTATION,
+        *,
+        sources: List[Dict[str, Any]],
     ) -> None:
         self.device = device
         self.velocity_representation = velocity_representation
@@ -299,16 +299,26 @@ class AMPLoader:
                     utils.string_to_callable(fn)
                 )
 
-        # ─── Parse dataset names and weights ───
-        dataset_names = list(datasets.keys())
-        dataset_weights = list(datasets.values())
+        # ─── Resolve sources ───
+        resolved_sources = [
+            (Path(s["dataset_path"]), s["motions"]) for s in sources
+        ]
+
+        # ─── Flatten all sources into names, weights, paths ───
+        all_names: List[str] = []
+        all_weights: List[float] = []
+        all_paths: List[Path] = []
+        for root, ds in resolved_sources:
+            for name, weight in ds.items():
+                all_names.append(name)
+                all_weights.append(weight)
+                all_paths.append(root / f"{name}.npy")
 
         # ─── Build union of all joint names if not provided ───
         if expected_joint_names is None:
             joint_union: List[str] = []
             seen = set()
-            for name in dataset_names:
-                p = dataset_path_root / f"{name}.npy"
+            for p in all_paths:
                 info = np.load(str(p), allow_pickle=True).item()
                 for j in info["joints_list"]:
                     if j not in seen:
@@ -319,8 +329,7 @@ class AMPLoader:
 
         # Load and process each dataset into MotionData
         self.motion_data: List[MotionData] = []
-        for dataset_name in dataset_names:
-            dataset_path = dataset_path_root / f"{dataset_name}.npy"
+        for dataset_path in all_paths:
             md = self.load_data(
                 dataset_path,
                 simulation_dt,
@@ -330,7 +339,7 @@ class AMPLoader:
             self.motion_data.append(md)
 
         # Normalize dataset-level sampling weights
-        weights = torch.tensor(dataset_weights, dtype=torch.float32, device=self.device)
+        weights = torch.tensor(all_weights, dtype=torch.float32, device=self.device)
         self.dataset_weights = weights / weights.sum()
 
         # Precompute flat buffers for fast sampling

--- a/amp_rsl_rl/utils/motion_loader.py
+++ b/amp_rsl_rl/utils/motion_loader.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 from pathlib import Path
-from typing import List, Union, Tuple, Generator, Dict
+from typing import Any, List, Union, Tuple, Generator, Dict
 from dataclasses import dataclass
 
 import torch
@@ -179,8 +179,8 @@ class AMPLoader:
 
     Args:
         device: Target torch device ('cpu' or 'cuda')
-        dataset_path_root: Directory containing the .npy motion files
-        datasets: Dictionary mapping dataset names (without extension) to sampling weights (floats)
+        sources: List of dicts, each with "dataset_path" and "motions" keys.
+            Supports loading motions from multiple directories.
         simulation_dt: Timestep used by the simulator
         slow_down_factor: Integer factor to slow down original data
         expected_joint_names: (Optional) override for joint ordering
@@ -189,26 +189,34 @@ class AMPLoader:
     def __init__(
         self,
         device: str,
-        dataset_path_root: Path,
-        datasets: Dict[str, float],
         simulation_dt: float,
         slow_down_factor: int,
         expected_joint_names: Union[List[str], None] = None,
+        *,
+        sources: List[Dict[str, Any]],
     ) -> None:
         self.device = device
-        if isinstance(dataset_path_root, str):
-            dataset_path_root = Path(dataset_path_root)
 
-        # ─── Parse dataset names and weights ───
-        dataset_names = list(datasets.keys())
-        dataset_weights = list(datasets.values())
+        # ─── Resolve sources ───
+        resolved_sources = [
+            (Path(s["dataset_path"]), s["motions"]) for s in sources
+        ]
+
+        # ─── Flatten all sources into names, weights, paths ───
+        all_names: List[str] = []
+        all_weights: List[float] = []
+        all_paths: List[Path] = []
+        for root, ds in resolved_sources:
+            for name, weight in ds.items():
+                all_names.append(name)
+                all_weights.append(weight)
+                all_paths.append(root / f"{name}.npy")
 
         # ─── Build union of all joint names if not provided ───
         if expected_joint_names is None:
             joint_union: List[str] = []
             seen = set()
-            for name in dataset_names:
-                p = dataset_path_root / f"{name}.npy"
+            for p in all_paths:
                 info = np.load(str(p), allow_pickle=True).item()
                 for j in info["joints_list"]:
                     if j not in seen:
@@ -219,8 +227,7 @@ class AMPLoader:
 
         # Load and process each dataset into MotionData
         self.motion_data: List[MotionData] = []
-        for dataset_name in dataset_names:
-            dataset_path = dataset_path_root / f"{dataset_name}.npy"
+        for dataset_path in all_paths:
             md = self.load_data(
                 dataset_path,
                 simulation_dt,
@@ -230,7 +237,7 @@ class AMPLoader:
             self.motion_data.append(md)
 
         # Normalize dataset-level sampling weights
-        weights = torch.tensor(dataset_weights, dtype=torch.float32, device=self.device)
+        weights = torch.tensor(all_weights, dtype=torch.float32, device=self.device)
         self.dataset_weights = weights / weights.sum()
 
         # Precompute flat buffers for fast sampling

--- a/amp_rsl_rl/utils/motion_loader.py
+++ b/amp_rsl_rl/utils/motion_loader.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
+from enum import Enum
 import inspect
 from pathlib import Path
 from typing import List, Union, Tuple, Generator, Dict, Optional, Any
@@ -13,6 +14,24 @@ import torch
 import numpy as np
 from scipy.spatial.transform import Rotation, Slerp
 from scipy.interpolate import interp1d
+
+
+class VelocityRepresentation(Enum):
+    """Velocity representation convention for base velocities.
+
+    Attributes:
+        BODY_FIXED_REPRESENTATION: Linear and angular velocities expressed in the
+            body-fixed (local) frame, i.e. using axes that rotate with the body.
+        MIXED_REPRESENTATION: Linear and angular velocities expressed using
+            world-aligned axes, but taken at the body origin. In other words, the
+            reference frame is attached to the body origin while its orientation
+            remains aligned with the world frame. This differs from
+            BODY_FIXED_REPRESENTATION, where the axes are attached to and rotate
+            with the body.
+    """
+
+    BODY_FIXED_REPRESENTATION = "body_fixed"
+    MIXED_REPRESENTATION = "mixed"
 
 
 def download_amp_dataset_from_hf(
@@ -151,16 +170,32 @@ class MotionData:
     def __len__(self) -> int:
         return self.joint_positions.shape[0]
 
-    def get_amp_dataset_obs(self, indices: torch.Tensor) -> torch.Tensor:
+    def get_amp_dataset_obs(
+        self,
+        indices: torch.Tensor,
+        velocity_representation: VelocityRepresentation = VelocityRepresentation.BODY_FIXED_REPRESENTATION,
+    ) -> torch.Tensor:
         """
         Returns the AMP observation tensor for given indices.
 
         Args:
             indices: indices of samples to retrieve
+            velocity_representation: which frame convention to use for the base
+                velocities in the observation. Defaults to BODY_FIXED_REPRESENTATION.
 
         Returns:
             Concatenated observation tensor
         """
+        if velocity_representation == VelocityRepresentation.MIXED_REPRESENTATION:
+            return torch.cat(
+                (
+                    self.joint_positions[indices],
+                    self.joint_velocities[indices],
+                    self.base_lin_velocities_mixed[indices],
+                    self.base_ang_velocities_mixed[indices],
+                ),
+                dim=1,
+            )
         return torch.cat(
             (
                 self.joint_positions[indices],
@@ -171,16 +206,31 @@ class MotionData:
             dim=1,
         )
 
-    def get_state_for_reset(self, indices: torch.Tensor) -> Tuple[torch.Tensor, ...]:
+    def get_state_for_reset(
+        self,
+        indices: torch.Tensor,
+        velocity_representation: VelocityRepresentation = VelocityRepresentation.BODY_FIXED_REPRESENTATION,
+    ) -> Tuple[torch.Tensor, ...]:
         """
         Returns the full state needed for environment reset.
 
         Args:
             indices: indices of samples to retrieve
+            velocity_representation: which frame convention to use for the returned
+                base velocities. Defaults to BODY_FIXED_REPRESENTATION for backward
+                compatibility.
 
         Returns:
             Tuple of (quat, joint_positions, joint_velocities, base_lin_velocities, base_ang_velocities)
         """
+        if velocity_representation == VelocityRepresentation.MIXED_REPRESENTATION:
+            return (
+                self.base_quat[indices],
+                self.joint_positions[indices],
+                self.joint_velocities[indices],
+                self.base_lin_velocities_mixed[indices],
+                self.base_ang_velocities_mixed[indices],
+            )
         return (
             self.base_quat[indices],
             self.joint_positions[indices],
@@ -189,9 +239,13 @@ class MotionData:
             self.base_ang_velocities_local[indices],
         )
 
-    def get_random_sample_for_reset(self, items: int = 1) -> Tuple[torch.Tensor, ...]:
+    def get_random_sample_for_reset(
+        self,
+        items: int = 1,
+        velocity_representation: VelocityRepresentation = VelocityRepresentation.BODY_FIXED_REPRESENTATION,
+    ) -> Tuple[torch.Tensor, ...]:
         indices = torch.randint(0, len(self), (items,), device=self.device)
-        return self.get_state_for_reset(indices)
+        return self.get_state_for_reset(indices, velocity_representation)
 
 
 class AMPLoader:
@@ -231,8 +285,10 @@ class AMPLoader:
         slow_down_factor: int,
         expected_joint_names: Union[List[str], None] = None,
         symmetry_cfg: Optional[Dict[str, Any]] = None,
+        velocity_representation: VelocityRepresentation = VelocityRepresentation.BODY_FIXED_REPRESENTATION,
     ) -> None:
         self.device = device
+        self.velocity_representation = velocity_representation
         if isinstance(dataset_path_root, str):
             dataset_path_root = Path(dataset_path_root)
         self.symmetry_cfg = symmetry_cfg
@@ -284,9 +340,9 @@ class AMPLoader:
         for data, w in zip(self.motion_data, self.dataset_weights):
             T = len(data)
             idx = torch.arange(T, device=self.device)
-            obs = data.get_amp_dataset_obs(idx)
+            obs = data.get_amp_dataset_obs(idx, self.velocity_representation)
             next_idx = torch.clamp(idx + 1, max=T - 1)
-            next_obs = data.get_amp_dataset_obs(next_idx)
+            next_obs = data.get_amp_dataset_obs(next_idx, self.velocity_representation)
 
             if self.symmetry_cfg and getattr(
                 self.symmetry_cfg, "use_amp_dataset_augmentation", False
@@ -298,7 +354,9 @@ class AMPLoader:
             next_obs_list.append(next_obs)
             augmented_lengths.append(obs.shape[0])
 
-            quat, jp, jv, blv, bav = data.get_state_for_reset(idx)
+            quat, jp, jv, blv, bav = data.get_state_for_reset(
+                idx, self.velocity_representation
+            )
             reset_states.append(torch.cat([quat, jp, jv, blv, bav], dim=1))
             original_lengths.append(T)
 
@@ -498,10 +556,15 @@ class AMPLoader:
             )
             yield self.all_obs[idx], self.all_next_obs[idx]
 
-    def get_state_for_reset(self, number_of_samples: int) -> Tuple[torch.Tensor, ...]:
+    def get_state_for_reset(
+        self,
+        number_of_samples: int,
+    ) -> Tuple[torch.Tensor, ...]:
         """
         Randomly samples full states for environment resets,
         sampled directly from the precomputed state buffer.
+
+        The velocity representation used is the one specified at construction time.
 
         Args:
             number_of_samples: Number of samples to retrieve

--- a/amp_rsl_rl/utils/motion_loader.py
+++ b/amp_rsl_rl/utils/motion_loader.py
@@ -3,9 +3,11 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
+import inspect
 from pathlib import Path
-from typing import List, Union, Tuple, Generator, Dict
+from typing import List, Union, Tuple, Generator, Dict, Optional, Any
 from dataclasses import dataclass
+from rsl_rl.utils import utils
 
 import torch
 import numpy as np
@@ -51,6 +53,40 @@ def download_amp_dataset_from_hf(
         dataset_names.append(file.replace(".npy", ""))
 
     return dataset_names
+
+
+def _call_augmentation_func(
+    fn,
+    *,
+    obs: Optional[torch.Tensor] = None,
+    actions: Optional[torch.Tensor] = None,
+    env: Any = None,
+    obs_type: Any = None,
+) -> tuple[Optional[torch.Tensor], Optional[torch.Tensor]]:
+    parameters = inspect.signature(fn).parameters
+    kwargs: Dict[str, Any] = {}
+
+    if "obs" in parameters:
+        kwargs["obs"] = obs
+
+    if "actions" in parameters:
+        kwargs["actions"] = actions
+
+    if "env" in parameters:
+        kwargs["env"] = env
+
+    if "cfg" in parameters and env is not None:
+        kwargs["cfg"] = getattr(env, "cfg", env)
+
+    if "obs_type" in parameters and obs_type is not None:
+        kwargs["obs_type"] = obs_type
+
+    result = fn(**kwargs)
+
+    if isinstance(result, tuple):
+        return result
+
+    return result, None
 
 
 @dataclass
@@ -194,10 +230,18 @@ class AMPLoader:
         simulation_dt: float,
         slow_down_factor: int,
         expected_joint_names: Union[List[str], None] = None,
+        symmetry_cfg: Optional[Dict[str, Any]] = None,
     ) -> None:
         self.device = device
         if isinstance(dataset_path_root, str):
             dataset_path_root = Path(dataset_path_root)
+        self.symmetry_cfg = symmetry_cfg
+        if self.symmetry_cfg is not None:
+            fn = getattr(self.symmetry_cfg, "amp_dataset_augmentation_func", None)
+            if isinstance(fn, str):
+                self.symmetry_cfg.amp_dataset_augmentation_func = (
+                    utils.string_to_callable(fn)
+                )
 
         # ─── Parse dataset names and weights ───
         dataset_names = list(datasets.keys())
@@ -235,6 +279,8 @@ class AMPLoader:
 
         # Precompute flat buffers for fast sampling
         obs_list, next_obs_list, reset_states = [], [], []
+        augmented_lengths: List[int] = []
+        original_lengths: List[int] = []
         for data, w in zip(self.motion_data, self.dataset_weights):
             T = len(data)
             idx = torch.arange(T, device=self.device)
@@ -242,25 +288,68 @@ class AMPLoader:
             next_idx = torch.clamp(idx + 1, max=T - 1)
             next_obs = data.get_amp_dataset_obs(next_idx)
 
+            if self.symmetry_cfg and getattr(
+                self.symmetry_cfg, "use_amp_dataset_augmentation", False
+            ):
+                obs = self._apply_symmetry(obs, obs_type="amp")
+                next_obs = self._apply_symmetry(next_obs, obs_type="amp")
+
             obs_list.append(obs)
             next_obs_list.append(next_obs)
+            augmented_lengths.append(obs.shape[0])
 
             quat, jp, jv, blv, bav = data.get_state_for_reset(idx)
             reset_states.append(torch.cat([quat, jp, jv, blv, bav], dim=1))
+            original_lengths.append(T)
 
         self.all_obs = torch.cat(obs_list, dim=0)
         self.all_next_obs = torch.cat(next_obs_list, dim=0)
         self.all_states = torch.cat(reset_states, dim=0)
 
-        # Build per-frame sampling weights: weight_i / length_i
-        lengths = [len(d) for d in self.motion_data]
+        # Build per-frame sampling weights for obs: weight_i / length_i
         per_frame = torch.cat(
             [
                 torch.full((L,), w / L, device=self.device)
-                for w, L in zip(self.dataset_weights, lengths)
+                for w, L in zip(self.dataset_weights, augmented_lengths)
             ]
         )
         self.per_frame_weights = per_frame / per_frame.sum()
+
+        # Build separate weights for reset states (not augmented)
+        per_frame_reset = torch.cat(
+            [
+                torch.full((L,), w / L, device=self.device)
+                for w, L in zip(self.dataset_weights, original_lengths)
+            ]
+        )
+        self.per_frame_weights_reset = per_frame_reset / per_frame_reset.sum()
+
+    def _apply_symmetry(
+        self,
+        *,
+        obs: Optional[torch.Tensor],
+        actions: Optional[torch.Tensor],
+        obs_type: Optional[Any] = None,
+    ) -> tuple[Optional[torch.Tensor], Optional[torch.Tensor]]:
+        if self.symmetry is None:
+            return obs, actions
+
+        aug_fn = self.symmetry.get("data_augmentation_func")
+        if aug_fn is None:
+            return obs, actions
+
+        aug_obs, aug_actions = _call_augmentation_func(
+            aug_fn,
+            obs=obs,
+            actions=actions,
+            env=self.symmetry.get("_env"),
+            obs_type=obs_type,
+        )
+
+        return (
+            aug_obs if aug_obs is not None else obs,
+            aug_actions if aug_actions is not None else actions,
+        )
 
     def _resample_data_Rn(
         self,
@@ -420,7 +509,7 @@ class AMPLoader:
             Tuple of (quat, joint_positions, joint_velocities, base_lin_velocities, base_ang_velocities)
         """
         idx = torch.multinomial(
-            self.per_frame_weights, number_of_samples, replacement=True
+            self.per_frame_weights_reset, number_of_samples, replacement=True
         )
         full = self.all_states[idx]
         joint_dim = self.motion_data[0].joint_positions.shape[1]

--- a/benchmarking/benchmark_download_and_loader.py
+++ b/benchmarking/benchmark_download_and_loader.py
@@ -74,11 +74,10 @@ def main():
         t0 = time.perf_counter()
         loader = AMPLoader(
             device=device,
-            dataset_path_root=local_dir,
-            datasets=datasets,
             simulation_dt=simulation_dt,
             slow_down_factor=slow_down_factor,
             expected_joint_names=joint_names,
+            sources=[{"dataset_path": str(local_dir), "motions": datasets}],
         )
         if device.type == "cuda":
             torch.cuda.synchronize()

--- a/example/load_amp_dataset.py
+++ b/example/load_amp_dataset.py
@@ -48,14 +48,13 @@ with tempfile.TemporaryDirectory() as tmpdirname:
     # DATASET PROCESSING WITH AMPLoader
     # =============================================
     # Initialize the AMPLoader to process and manage the motion data
+    datasets = {name: 1.0 for name in dataset_names}
     loader = AMPLoader(
         device="cpu",  # Use CPU for processing (change to "cuda" for GPU)
-        dataset_path_root=local_dir,  # Path to downloaded datasets
-        dataset_names=dataset_names,  # Names of the loaded datasets
-        dataset_weights=[1.0] * len(dataset_names),  # Equal weights for all motions
         simulation_dt=1 / 60.0,  # Simulation timestep (60Hz)
         slow_down_factor=1,  # Don't slow down the motions
         expected_joint_names=None,  # Use default joint ordering
+        sources=[{"dataset_path": str(local_dir), "motions": datasets}],
     )
 
     # =============================================


### PR DESCRIPTION
## Summary

Refactors `AMPLoader` to accept motion datasets from multiple directories via a `sources` parameter, instead of being limited to a single `dataset_path_root`.

## Changes

- **`amp_rsl_rl/utils/motion_loader.py`** — `AMPLoader.__init__` now takes a keyword-only `sources: List[Dict]` parameter. Each dict has `"dataset_path"` (root directory) and `"motions"` (name→weight mapping). Removes the old `dataset_path_root`/`datasets` parameters.
- **`amp_rsl_rl/runners/amp_on_policy_runner.py`** — Passes `sources=self.dataset_cfg["sources"]` to `AMPLoader`. Updated docstring.
- **`example/load_amp_dataset.py`** — Updated to use new API.
- **`benchmarking/benchmark_download_and_loader.py`** — Updated to use new API.

## Breaking Changes

`AMPLoader` no longer accepts `dataset_path_root` or `datasets` as arguments. Callers must pass:

```python
AMPLoader(
    device=...,
    simulation_dt=...,
    slow_down_factor=...,
    sources=[{"dataset_path": "/path/to/dir", "motions": {"Walk": 1.0, "Run": 0.5}}],
)
```

## Motivation

The old API forced all motions to live under a single directory. This makes it impossible to compose motion priors from different retargeting pipelines or dataset collections without copying files around. The new `sources` list allows mixing motions from arbitrary paths.