### PR TITLE
Cast fps data based on its type

### DIFF
--- a/amp_rsl_rl/utils/motion_loader.py
+++ b/amp_rsl_rl/utils/motion_loader.py
@@ -484,7 +484,11 @@ class AMPLoader:
                     arr[i] = frame[src_idx]
             jp_list.append(arr)
 
-        dt = 1.0 / data["fps"] / float(slow_down_factor)
+        if isinstance(data["fps"], np.ndarray):
+            fps = float(data["fps"].reshape(-1)[0])
+        else:
+            fps = float(data["fps"])
+        dt = 1.0 / fps / float(slow_down_factor)
         T = len(jp_list)
         t_orig = np.linspace(0, T * dt, T)
         T_new = int(T * dt / simulation_dt)


### PR DESCRIPTION
Resulting error without the fix.
```
[INFO]: Starting the simulation. This may take a few seconds. Please wait...
Traceback (most recent call last):
  File "IsaacLabv/source/isaaclab/isaaclab/managers/manager_base.py", line 169, in <lambda>
    lambda event, obj=weakref.proxy(self): obj._resolve_terms_callback(event),
                        [INFO]: Starting the simulation. This may take a few seconds. Please wait...
Traceback (most recent call last):
  File "IsaacLab/source/isaaclab/isaaclab/managers/manager_base.py", line 169, in <lambda>
    lambda event, obj=weakref.proxy(self): obj._resolve_terms_callback(event),
                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "IsaacLab/source/isaaclab/isaaclab/managers/manager_base.py", line 292, in _resolve_terms_callback
    self._process_term_cfg_at_play(term_name, term_cfg)
  File "IsaacLab/source/isaaclab/isaaclab/managers/manager_base.py", line 418, in _process_term_cfg_at_play
    term_cfg.func = term_cfg.func(cfg=term_cfg, env=self._env)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "reset.py", line 56, in __init__
    self.amp_data: AMPLoader = AMPLoader(
                               ^^^^^^^^^^
  File "amp-rsl-rl/amp_rsl_rl/utils/motion_loader.py", line 330, in __init__
    md = self.load_data(
         ^^^^^^^^^^^^^^^
  File "amp-rsl-rl/amp_rsl_rl/utils/motion_loader.py", line 494, in load_data
    resampled_joint_positions = self._resample_data_Rn(jp_list, t_orig, t_new)
                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "amp-rsl-rl/amp_rsl_rl/utils/motion_loader.py", line 414, in _resample_data_Rn
    f = interp1d(original_keyframes, data, axis=0)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/hhamed/miniforge3/envs/env_isaaclab/lib/python3.11/site-packages/scipy/interpolate/_interpolate.py", line 297, in __init__
    raise ValueError("the x array must have exactly one dimension.")
```

The fix keeps backcompatibility for the data type of fps