### PR TITLE
Add rollout storage helpers for dtype preservation in AMP training

### DIFF
--- a/amp_rsl_rl/algorithms/amp_ppo.py
+++ b/amp_rsl_rl/algorithms/amp_ppo.py
@@ -15,7 +15,7 @@ from tensordict import TensorDict
 
 from rsl_rl.storage import RolloutStorage
 
-from amp_rsl_rl.storage import ReplayBuffer
+from amp_rsl_rl.storage import ReplayBuffer, build_rollout_storage
 from amp_rsl_rl.networks import Discriminator
 from amp_rsl_rl.utils import AMPLoader, _call_augmentation_func
 from amp_rsl_rl.utils._compat import RSL_RL_V3_3_PLUS, RSL_RL_V4_PLUS, RSL_RL_V5_PLUS
@@ -236,7 +236,7 @@ class AMP_PPO:
         action_shape : Tuple[int, ...]
             Shape of the action vector output by the policy.
         """
-        self.storage = RolloutStorage(
+        self.storage = build_rollout_storage(
             training_type="rl",
             num_envs=num_envs,
             num_transitions_per_env=num_transitions_per_env,

--- a/amp_rsl_rl/storage/__init__.py
+++ b/amp_rsl_rl/storage/__init__.py
@@ -7,5 +7,6 @@
 """Implementation of replay buffer for storing and sampling data."""
 
 from .replay_buffer import ReplayBuffer
+from .rollout_storage import build_rollout_storage, preserve_observation_dtypes
 
-__all__ = ["ReplayBuffer"]
+__all__ = ["ReplayBuffer", "build_rollout_storage", "preserve_observation_dtypes"]

--- a/amp_rsl_rl/storage/rollout_storage.py
+++ b/amp_rsl_rl/storage/rollout_storage.py
@@ -1,0 +1,96 @@
+# SPDX-FileCopyrightText: Generative Bionics S.R.L.
+# SPDX-License-Identifier: LicenseRef-GenerativeBionics-AllRightsReserved
+
+"""Rollout storage helpers for AMP training.
+
+This module backports the observation-dtype preservation that landed in
+``rsl-rl-lib`` v5.4.0 (upstream PR #212, "Preserve observation tensors dtype in
+the rollout storage") so that AMP training benefits from it on *every* supported
+``rsl-rl-lib`` version (v3.x through v5.x).
+
+Why it matters
+--------------
+Older ``rsl-rl-lib`` allocated the rollout observation buffer with
+``torch.zeros(..., device=device)``, which always yields ``float32`` regardless
+of the observation dtype. Vision-based observations (e.g. ``uint8`` depth/RGB
+images) were therefore stored at 4x their real size, wasting GPU memory and, at
+large environment counts, causing out-of-memory failures. Preserving the native
+dtype keeps ``uint8`` observations as ``uint8`` in the buffer.
+
+For the common AMP case where all observations are ``float32`` this helper is a
+no-op, and on ``rsl-rl-lib`` >= 5.4.0 it is a no-op as well (the native storage
+already preserves dtypes).
+"""
+
+from __future__ import annotations
+
+import torch
+from tensordict import TensorDict
+
+from rsl_rl.storage import RolloutStorage
+
+__all__ = ["build_rollout_storage", "preserve_observation_dtypes"]
+
+
+def preserve_observation_dtypes(
+    storage: RolloutStorage, obs_prototype: TensorDict
+) -> RolloutStorage:
+    """Ensure the rollout observation buffer matches the prototype dtypes.
+
+    Reallocates only the observation groups whose buffer dtype differs from the
+    prototype (i.e. those the underlying storage upcast to ``float32``). Groups
+    that already match are left untouched, so this is a no-op on dtype-preserving
+    ``rsl-rl-lib`` versions and for ``float32``-only observations.
+
+    Parameters
+    ----------
+    storage : RolloutStorage
+        Freshly constructed storage whose ``observations`` buffer may have been
+        allocated with a coerced dtype.
+    obs_prototype : TensorDict
+        The observation TensorDict used to size the storage; carries the desired
+        per-group dtypes.
+
+    Returns
+    -------
+    RolloutStorage
+        The same storage instance, with dtype-corrected observation buffers.
+    """
+    observations = storage.observations
+    for key, proto in obs_prototype.items():
+        proto_dtype = getattr(proto, "dtype", None)
+        if proto_dtype is None:
+            continue
+        buffer = observations[key]
+        if buffer.dtype == proto_dtype:
+            continue
+        observations.set(
+            key,
+            torch.zeros(buffer.shape, dtype=proto_dtype, device=buffer.device),
+        )
+    return storage
+
+
+def build_rollout_storage(
+    *,
+    num_envs: int,
+    num_transitions_per_env: int,
+    obs: TensorDict,
+    actions_shape,
+    device: str,
+    training_type: str = "rl",
+) -> RolloutStorage:
+    """Build an ``rsl_rl`` ``RolloutStorage`` with observation dtypes preserved.
+
+    Drop-in replacement for constructing ``RolloutStorage`` directly. See the
+    module docstring for the motivation.
+    """
+    storage = RolloutStorage(
+        training_type=training_type,
+        num_envs=num_envs,
+        num_transitions_per_env=num_transitions_per_env,
+        obs=obs,
+        actions_shape=actions_shape,
+        device=device,
+    )
+    return preserve_observation_dtypes(storage, obs)

--- a/benchmarking/benchmark_rollout_storage_memory.py
+++ b/benchmarking/benchmark_rollout_storage_memory.py
@@ -1,0 +1,91 @@
+# SPDX-FileCopyrightText: Generative Bionics S.R.L.
+# SPDX-License-Identifier: LicenseRef-GenerativeBionics-AllRightsReserved
+
+"""Quantify the rollout-buffer memory saved by preserving observation dtypes.
+
+This reproduces the effect behind the rsl-rl-lib v5.4.0 speed/memory improvement
+(upstream PR #212) that ``amp_rsl_rl.storage.build_rollout_storage`` backports to
+all supported versions: non-float observations (e.g. ``uint8`` camera frames)
+are kept at their native dtype instead of being upcast to ``float32``.
+
+Run:
+    python benchmarking/benchmark_rollout_storage_memory.py
+"""
+
+import torch
+from tensordict import TensorDict
+from importlib.metadata import version
+
+from rsl_rl.storage import RolloutStorage
+from amp_rsl_rl.storage import build_rollout_storage
+
+# =============================================
+# CONFIGURATION
+# =============================================
+device_str = "cuda" if torch.cuda.is_available() else "cpu"
+num_envs = 4096
+horizon = 24
+proprio_dim = 48
+critic_dim = 60
+camera_shape = (1, 58, 87)  # single-channel depth image, uint8
+
+
+def _obs_prototype() -> TensorDict:
+    return TensorDict(
+        {
+            "policy": torch.zeros(num_envs, proprio_dim, dtype=torch.float32),
+            "critic": torch.zeros(num_envs, critic_dim, dtype=torch.float32),
+            "camera": torch.zeros(num_envs, *camera_shape, dtype=torch.uint8),
+        },
+        batch_size=[num_envs],
+    )
+
+
+def _buffer_mb(storage) -> float:
+    total = sum(v.element_size() * v.nelement() for v in storage.observations.values())
+    return total / 1e6
+
+
+def main() -> None:
+    device = torch.device(device_str)
+    print(f"\n[RolloutStorage Memory Benchmark] Device: {device}")
+    print(f"rsl-rl-lib=={version('rsl-rl-lib')}")
+    print(f"num_envs={num_envs}, horizon={horizon}, camera={camera_shape} (uint8)\n")
+
+    # Native rsl_rl storage (dtype behaviour depends on installed version).
+    native = RolloutStorage(
+        training_type="rl",
+        num_envs=num_envs,
+        num_transitions_per_env=horizon,
+        obs=_obs_prototype(),
+        actions_shape=(12,),
+        device=device_str,
+    )
+    native_mb = _buffer_mb(native)
+    native_dtypes = {k: str(v.dtype) for k, v in native.observations.items()}
+
+    # amp_rsl_rl storage with the dtype-preserving backport applied.
+    preserved = build_rollout_storage(
+        num_envs=num_envs,
+        num_transitions_per_env=horizon,
+        obs=_obs_prototype(),
+        actions_shape=(12,),
+        device=device_str,
+    )
+    preserved_mb = _buffer_mb(preserved)
+    preserved_dtypes = {k: str(v.dtype) for k, v in preserved.observations.items()}
+
+    print(f"[native  RolloutStorage] dtypes={native_dtypes}")
+    print(f"[native  RolloutStorage] obs buffer = {native_mb:8.2f} MB")
+    print(f"[amp build_rollout_storage] dtypes={preserved_dtypes}")
+    print(f"[amp build_rollout_storage] obs buffer = {preserved_mb:8.2f} MB")
+
+    if preserved_mb < native_mb:
+        print(f"\n=> {native_mb / preserved_mb:.2f}x less rollout-buffer memory "
+              f"({native_mb - preserved_mb:.1f} MB saved).")
+    else:
+        print("\n=> Installed rsl-rl-lib already preserves dtypes; backport is a no-op.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_rollout_storage_dtype.py
+++ b/tests/test_rollout_storage_dtype.py
@@ -1,0 +1,115 @@
+# SPDX-FileCopyrightText: Generative Bionics S.R.L.
+# SPDX-License-Identifier: LicenseRef-GenerativeBionics-AllRightsReserved
+
+"""Tests for the dtype-preserving rollout storage backport.
+
+Verifies that AMP training keeps non-float observation groups (e.g. ``uint8``
+images) at their native dtype in the rollout buffer, mirroring rsl-rl-lib
+v5.4.0's behaviour on every supported version.
+
+Run with:
+    python -m pytest tests/test_rollout_storage_dtype.py -v
+"""
+
+import torch
+from tensordict import TensorDict
+
+from amp_rsl_rl.storage import build_rollout_storage, preserve_observation_dtypes
+
+
+def _make_obs(num_envs: int) -> TensorDict:
+    return TensorDict(
+        {
+            "policy": torch.zeros(num_envs, 48, dtype=torch.float32),
+            "critic": torch.zeros(num_envs, 60, dtype=torch.float32),
+            "camera": torch.zeros(num_envs, 1, 32, 32, dtype=torch.uint8),
+        },
+        batch_size=[num_envs],
+    )
+
+
+def _obs_buffer_bytes(storage) -> int:
+    return sum(v.element_size() * v.nelement() for v in storage.observations.values())
+
+
+def test_build_rollout_storage_preserves_dtypes():
+    """Each observation group keeps its native dtype in the buffer."""
+    num_envs, horizon = 64, 8
+    obs = _make_obs(num_envs)
+
+    storage = build_rollout_storage(
+        num_envs=num_envs,
+        num_transitions_per_env=horizon,
+        obs=obs,
+        actions_shape=(12,),
+        device="cpu",
+    )
+
+    assert storage.observations["policy"].dtype == torch.float32
+    assert storage.observations["critic"].dtype == torch.float32
+    assert storage.observations["camera"].dtype == torch.uint8
+
+    # Shapes must match the (horizon, num_envs, *feature) layout.
+    assert tuple(storage.observations["camera"].shape) == (horizon, num_envs, 1, 32, 32)
+
+
+def test_uint8_obs_uses_less_memory_than_float32():
+    """Preserving uint8 cuts the buffer to a quarter of the coerced size."""
+    num_envs, horizon = 128, 8
+    obs = _make_obs(num_envs)
+
+    storage = build_rollout_storage(
+        num_envs=num_envs,
+        num_transitions_per_env=horizon,
+        obs=obs,
+        actions_shape=(12,),
+        device="cpu",
+    )
+    preserved = storage.observations["camera"]
+
+    coerced_bytes = preserved.nelement() * torch.empty(0, dtype=torch.float32).element_size()
+    preserved_bytes = preserved.element_size() * preserved.nelement()
+
+    assert preserved_bytes * 4 == coerced_bytes
+
+
+def test_preserve_is_noop_when_dtypes_match():
+    """Float32-only observations are left untouched (idempotent)."""
+    num_envs, horizon = 32, 4
+    obs = TensorDict(
+        {"policy": torch.zeros(num_envs, 16, dtype=torch.float32)},
+        batch_size=[num_envs],
+    )
+    storage = build_rollout_storage(
+        num_envs=num_envs,
+        num_transitions_per_env=horizon,
+        obs=obs,
+        actions_shape=(4,),
+        device="cpu",
+    )
+    before = storage.observations["policy"]
+    preserve_observation_dtypes(storage, obs)
+    # Same object identity: no reallocation happened.
+    assert storage.observations["policy"] is before
+
+
+def test_stored_uint8_values_round_trip():
+    """Writing an observation into the buffer preserves uint8 values exactly."""
+    num_envs, horizon = 16, 4
+    obs = _make_obs(num_envs)
+    storage = build_rollout_storage(
+        num_envs=num_envs,
+        num_transitions_per_env=horizon,
+        obs=obs,
+        actions_shape=(12,),
+        device="cpu",
+    )
+
+    step_obs = obs.clone()
+    step_obs["camera"] = torch.randint(0, 256, (num_envs, 1, 32, 32), dtype=torch.uint8)
+
+    # This mirrors what RolloutStorage.add_transition does internally.
+    storage.observations[0].copy_(step_obs)
+
+    assert storage.observations["camera"][0].dtype == torch.uint8
+    assert torch.equal(storage.observations["camera"][0], step_obs["camera"])


### PR DESCRIPTION
Introduce helpers to preserve observation dtypes in rollout storage for AMP training, ensuring efficient memory usage by maintaining native dtypes for non-float observations. This change backports functionality from a newer version of `rsl-rl-lib` to enhance compatibility across supported versions.

